### PR TITLE
83: fix: filter negative completion_hours_business values in temporal_features

### DIFF
--- a/apps/training/tests/test_transform_pipeline.py
+++ b/apps/training/tests/test_transform_pipeline.py
@@ -73,6 +73,29 @@ class TestTemporalFeatures:
 
     assert hours is None
 
+  def test_compute_returns_none_for_negative_duration(self) -> None:
+    """Test returns None when closed_at is before assigned_at.
+
+    This handles data quality issues where tickets have timestamp
+    inconsistencies, e.g. closed and reopened tickets.
+    """
+    created = "2026-01-01T10:00:00Z"
+    assigned = "2026-01-02T10:00:00Z"
+    closed = "2026-01-01T10:00:00Z"  # closed before assigned
+
+    hours = compute_business_completion_hours(created, assigned, closed)
+
+    assert hours is None
+
+  def test_compute_returns_none_when_closed_before_created(self) -> None:
+    """Test returns None when closed_at is before created_at."""
+    created = "2026-01-05T10:00:00Z"
+    closed = "2026-01-01T10:00:00Z"  # closed before created
+
+    hours = compute_business_completion_hours(created, None, closed)
+
+    assert hours is None
+
 
 class TestKeywordExtraction:
   """Test keyword extraction."""

--- a/apps/training/training/etl/transform/temporal_features.py
+++ b/apps/training/training/etl/transform/temporal_features.py
@@ -18,7 +18,9 @@ def compute_business_completion_hours(
       closed_at: ISO datetime string when ticket was closed
 
   Returns:
-      Business hours or None if closed_at is missing
+      Business hours or None if closed_at is missing or result is negative
+      (which indicates a data quality issue where closed_at is earlier than
+      the start time, e.g. tickets closed and reopened or timestamp errors).
   """
   if closed_at is None or pd.isna(closed_at):
     return None
@@ -33,6 +35,12 @@ def compute_business_completion_hours(
     start = pd.to_datetime(start_time)
     end = pd.to_datetime(closed_at)
     total_hours = (end - start).total_seconds() / 3600
+
+    # Return None for negative durations — indicates a data quality issue
+    # where closed_at is earlier than start time (e.g. tickets that were
+    # closed and reopened, or timestamp inconsistencies in the GitHub API).
+    if total_hours < 0:
+      return None
 
     # Approximate business hours (exclude weekends: ~5/7 of total time)
     business_hours = total_hours * (5 / 7)


### PR DESCRIPTION
## Description

### Motivation
Resolves: #83

Some scraped tickets have `closed_at` timestamps earlier than `assigned_at` or `created_at`, resulting in negative `completion_hours_business` values in the training data. This is a data quality issue caused by tickets that were closed and reopened, or timestamp inconsistencies in the GitHub API. Negative durations are meaningless as regression targets and should be excluded.

### Implemented Changes
- Updated `compute_business_completion_hours()` in `temporal_features.py` to return `None` if the computed duration is negative, treating it the same as a missing value
- Added a comment explaining the root cause (data quality issue, not a code bug)

## How has this been tested?
- Added `test_compute_returns_none_for_negative_duration` — verifies `None` is returned when `closed_at` is before `assigned_at`
- Added `test_compute_returns_none_when_closed_before_created` — verifies `None` is returned when `closed_at` is before `created_at`
- All 219 tests passing with `just check`

## Screenshots
N/A

## Checklist:
- [x] I followed code style of the project.
- [x] I've updated all documentation accordingly.
- [x] I've added tests to cover my changes.
- [x] I've ensured all tests pass (no regressions).