### PR TITLE
feat: persist auto-sized tickets on the project board

### DIFF
--- a/apps/web-backend/README.md
+++ b/apps/web-backend/README.md
@@ -8,6 +8,7 @@ RESTful API backend that:
 - Serves predictions from trained ML models
 - Pins the deployed revision to an exact MLflow Production model version
 - Persists inference telemetry for monitoring and drift detection
+- Persists AI-estimated ticket size buckets on project board tickets
 - Handles ticket assignment recommendations
 - Provides health checks and status endpoints
 
@@ -44,6 +45,15 @@ Authenticated recommendation endpoints:
 
 - `GET /api/v1/projects/{slug}/tickets/{ticket_key}/recommendations/engineers`
 - `GET /api/v1/projects/{slug}/members/{user_id}/recommendations/tickets`
+
+Key project ticket sizing behavior:
+
+- `POST /api/v1/projects/{slug}/tickets`
+  - auto-predicts a ticket size when no manual bucket is provided
+- `PATCH /api/v1/projects/{slug}/tickets/{ticket_key}`
+  - preserves manual size overrides and re-runs prediction when tickets return to auto mode
+- `POST /api/v1/projects/{slug}/tickets/classify-missing`
+  - batch-classifies legacy unsized tickets for a project and persists the buckets
 
 ## Structure
 

--- a/apps/web-backend/tests/test_ticket_sizing.py
+++ b/apps/web-backend/tests/test_ticket_sizing.py
@@ -1,0 +1,171 @@
+"""Tests for project ticket sizing behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+VALID_SIGNUP = {
+    "username": "sizeuser",
+    "first_name": "Size",
+    "last_name": "Tester",
+    "email": "size@example.com",
+    "password": "SecurePass1",
+}
+
+
+async def _auth_headers(client) -> dict[str, str]:
+    """Create a user and return bearer auth headers for API calls."""
+    response = await client.post("/api/v1/auth/signup", json=VALID_SIGNUP)
+    assert response.status_code == 201
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_project(client, headers: dict[str, str]) -> dict:
+    """Create a project using the API and return its JSON payload."""
+    response = await client.post(
+        "/api/v1/projects",
+        headers=headers,
+        json={"name": "Sizing Demo", "board_columns": [], "member_ids": []},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_auto_predicts_size(client) -> None:
+    """New tickets should be auto-sized when no manual bucket is provided."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    fake_prediction = SimpleNamespace(predicted_bucket="L", confidence=0.91)
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(return_value=fake_prediction),
+    ):
+        response = await client.post(
+            f"/api/v1/projects/{project['slug']}/tickets",
+            headers=headers,
+            json={"title": "Ship production sizing flow", "column_id": column_id},
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["size_bucket"] == "L"
+    assert payload["size_source"] == "predicted"
+    assert payload["size_confidence"] == 0.91
+
+
+@pytest.mark.asyncio
+async def test_manual_ticket_size_skips_reprediction_on_update(client) -> None:
+    """Manual ticket sizes should remain authoritative across edits."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    create_response = await client.post(
+        f"/api/v1/projects/{project['slug']}/tickets",
+        headers=headers,
+        json={
+            "title": "Manual size ticket",
+            "column_id": column_id,
+            "size_bucket": "M",
+        },
+    )
+    assert create_response.status_code == 201
+
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(),
+    ) as mock_predict:
+        update_response = await client.patch(
+            f"/api/v1/projects/{project['slug']}/tickets/"
+            f"{create_response.json()['ticket_key']}",
+            headers=headers,
+            json={"title": "Manual size ticket updated"},
+        )
+
+    assert update_response.status_code == 200
+    payload = update_response.json()
+    assert payload["size_bucket"] == "M"
+    assert payload["size_source"] == "manual"
+    assert payload["size_confidence"] is None
+    mock_predict.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clearing_manual_size_recomputes_prediction(client) -> None:
+    """Switching back to auto mode should recompute and persist an AI size."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    create_response = await client.post(
+        f"/api/v1/projects/{project['slug']}/tickets",
+        headers=headers,
+        json={
+            "title": "Manual size ticket",
+            "column_id": column_id,
+            "size_bucket": "S",
+        },
+    )
+    assert create_response.status_code == 201
+    ticket_key = create_response.json()["ticket_key"]
+
+    fake_prediction = SimpleNamespace(predicted_bucket="XL", confidence=0.66)
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(return_value=fake_prediction),
+    ):
+        response = await client.patch(
+            f"/api/v1/projects/{project['slug']}/tickets/{ticket_key}",
+            headers=headers,
+            json={"size_bucket": None},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["size_bucket"] == "XL"
+    assert payload["size_source"] == "predicted"
+    assert payload["size_confidence"] == 0.66
+
+
+@pytest.mark.asyncio
+async def test_classify_missing_endpoint_backfills_unsized_tickets(client) -> None:
+    """Batch sizing endpoint should backfill legacy unsized project tickets."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(side_effect=RuntimeError("temporary inference outage")),
+    ):
+        create_response = await client.post(
+            f"/api/v1/projects/{project['slug']}/tickets",
+            headers=headers,
+            json={"title": "Legacy unsized ticket", "column_id": column_id},
+        )
+
+    assert create_response.status_code == 201
+    assert create_response.json()["size_bucket"] is None
+
+    fake_prediction = SimpleNamespace(predicted_bucket="M", confidence=0.58)
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(return_value=fake_prediction),
+    ):
+        response = await client.post(
+            f"/api/v1/projects/{project['slug']}/tickets/classify-missing",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["updated_count"] == 1
+    assert payload["tickets"][0]["size_bucket"] == "M"
+    assert payload["tickets"][0]["size_source"] == "predicted"

--- a/apps/web-backend/tests/test_ticket_sizing.py
+++ b/apps/web-backend/tests/test_ticket_sizing.py
@@ -169,3 +169,45 @@ async def test_classify_missing_endpoint_backfills_unsized_tickets(client) -> No
     assert payload["updated_count"] == 1
     assert payload["tickets"][0]["size_bucket"] == "M"
     assert payload["tickets"][0]["size_source"] == "predicted"
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_can_clear_optional_fields(client) -> None:
+    """Ticket updates should allow clearing nullable board fields."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(
+            return_value=SimpleNamespace(predicted_bucket="M", confidence=0.7)
+        ),
+    ):
+        create_response = await client.post(
+            f"/api/v1/projects/{project['slug']}/tickets",
+            headers=headers,
+            json={
+                "title": "Ticket with optional fields",
+                "column_id": column_id,
+                "description": "Needs refinement",
+                "due_date": "2026-04-10",
+            },
+        )
+
+    assert create_response.status_code == 201
+    ticket_key = create_response.json()["ticket_key"]
+
+    update_response = await client.patch(
+        f"/api/v1/projects/{project['slug']}/tickets/{ticket_key}",
+        headers=headers,
+        json={
+            "description": None,
+            "due_date": None,
+        },
+    )
+
+    assert update_response.status_code == 200
+    payload = update_response.json()
+    assert payload["description"] is None
+    assert payload["due_date"] is None

--- a/apps/web-backend/tests/test_ticket_sizing.py
+++ b/apps/web-backend/tests/test_ticket_sizing.py
@@ -16,6 +16,19 @@ VALID_SIGNUP = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _stub_recommendation_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep sizing tests focused by bypassing recommendation sync side effects."""
+    monkeypatch.setattr(
+        "web_backend.services.tickets.sync_project_ticket_to_ml_tables",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "web_backend.services.tickets.apply_ticket_completion_profile_update",
+        AsyncMock(),
+    )
+
+
 async def _auth_headers(client) -> dict[str, str]:
     """Create a user and return bearer auth headers for API calls."""
     response = await client.post("/api/v1/auth/signup", json=VALID_SIGNUP)

--- a/apps/web-backend/web_backend/api/v1/tickets.py
+++ b/apps/web-backend/web_backend/api/v1/tickets.py
@@ -11,6 +11,7 @@ from web_backend.database import get_db
 from web_backend.models.user import AuthUser
 from web_backend.schemas.tickets import (
     BoardTicketsResponse,
+    TicketBatchSizingResponse,
     TicketAssigneeResponse,
     TicketCreateRequest,
     TicketMoveRequest,
@@ -19,6 +20,7 @@ from web_backend.schemas.tickets import (
 )
 from web_backend.security.dependencies import get_current_user
 from web_backend.services.tickets import (
+    classify_missing_ticket_sizes,
     create_ticket,
     delete_ticket,
     get_board_tickets,
@@ -56,6 +58,10 @@ def _ticket_to_response(ticket) -> TicketResponse:
         priority=ticket.priority,
         type=ticket.type,
         labels=ticket.labels,
+        size_bucket=ticket.size_bucket,
+        size_source=ticket.size_source,
+        size_confidence=ticket.size_confidence,
+        size_updated_at=ticket.size_updated_at,
         due_date=ticket.due_date,
         position=ticket.position,
         assignee=assignee,
@@ -114,6 +120,36 @@ async def create_ticket_endpoint(
         ) from exc
 
     return _ticket_to_response(ticket)
+
+
+# ------------------------------------------------------------------ #
+#  POST /projects/:slug/tickets/classify-missing — backfill AI sizes
+# ------------------------------------------------------------------ #
+
+
+@router.post("/classify-missing", response_model=TicketBatchSizingResponse)
+async def classify_missing_ticket_sizes_endpoint(
+    slug: str,
+    current_user: AuthUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TicketBatchSizingResponse:
+    """Classify and persist any tickets that do not have a stored size."""
+    try:
+        updated_count, tickets = await classify_missing_ticket_sizes(
+            db,
+            slug,
+            current_user.id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+    return TicketBatchSizingResponse(
+        updated_count=updated_count,
+        tickets=[_ticket_to_response(ticket) for ticket in tickets],
+    )
 
 
 # ------------------------------------------------------------------ #

--- a/apps/web-backend/web_backend/models/ticket.py
+++ b/apps/web-backend/web_backend/models/ticket.py
@@ -4,11 +4,13 @@
 # pylint: disable=unsubscriptable-object
 
 import uuid
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import (
     Date,
+    DateTime,
     Enum,
+    Float,
     ForeignKey,
     Integer,
     JSON,
@@ -86,6 +88,13 @@ class ProjectTicket(TimestampMixin, Base):
         default="task",
     )
     labels: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    size_bucket: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    size_source: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    size_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    size_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
     due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/apps/web-backend/web_backend/schemas/tickets.py
+++ b/apps/web-backend/web_backend/schemas/tickets.py
@@ -20,6 +20,7 @@ class TicketCreateRequest(BaseModel):
     priority: str = Field(default="medium", pattern="^(low|medium|high|critical)$")
     type: str = Field(default="task", pattern="^(task|story|bug)$")
     labels: list[str] = Field(default=[])
+    size_bucket: str | None = Field(None, pattern="^(S|M|L|XL)$")
     due_date: date | None = None
     assignee_id: uuid.UUID | None = None
 
@@ -37,6 +38,7 @@ class TicketUpdateRequest(BaseModel):
     priority: str | None = Field(None, pattern="^(low|medium|high|critical)$")
     type: str | None = Field(None, pattern="^(task|story|bug)$")
     labels: list[str] | None = None
+    size_bucket: str | None = Field(None, pattern="^(S|M|L|XL)$")
     due_date: date | None = None
     assignee_id: uuid.UUID | None = None
 
@@ -82,6 +84,10 @@ class TicketResponse(BaseModel):
     priority: str
     type: str
     labels: list[str]
+    size_bucket: str | None
+    size_source: str | None
+    size_confidence: float | None
+    size_updated_at: datetime | None
     due_date: date | None
     position: int
     assignee: TicketAssigneeResponse | None = None
@@ -95,4 +101,11 @@ class TicketResponse(BaseModel):
 class BoardTicketsResponse(BaseModel):
     """All tickets for a project, grouped for the board."""
 
+    tickets: list[TicketResponse]
+
+
+class TicketBatchSizingResponse(BaseModel):
+    """Result payload for on-demand project ticket sizing."""
+
+    updated_count: int
     tickets: list[TicketResponse]

--- a/apps/web-backend/web_backend/schemas/tickets.py
+++ b/apps/web-backend/web_backend/schemas/tickets.py
@@ -19,7 +19,7 @@ class TicketCreateRequest(BaseModel):
     column_id: uuid.UUID
     priority: str = Field(default="medium", pattern="^(low|medium|high|critical)$")
     type: str = Field(default="task", pattern="^(task|story|bug)$")
-    labels: list[str] = Field(default=[])
+    labels: list[str] = Field(default_factory=list)
     size_bucket: str | None = Field(None, pattern="^(S|M|L|XL)$")
     due_date: date | None = None
     assignee_id: uuid.UUID | None = None

--- a/apps/web-backend/web_backend/services/tickets.py
+++ b/apps/web-backend/web_backend/services/tickets.py
@@ -1,10 +1,11 @@
 """Ticket business logic.
 
-Handles ticket creation, updates, moves (drag-and-drop), and deletion.
-Routes call these — no direct DB queries in routes.
+Handles ticket creation, updates, sizing, moves (drag-and-drop),
+and deletion. Routes call these — no direct DB queries in routes.
 """
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +14,7 @@ from sqlalchemy.orm import selectinload
 from web_backend.models.project import Project, ProjectBoardColumn, ProjectMember
 from web_backend.models.ticket import ProjectTicket, ProjectTicketCounter
 from web_backend.models.user import AuthUser
+from web_backend.schemas.inference import TicketSizePredictionRequest
 from web_backend.schemas.tickets import (
     TicketCreateRequest,
     TicketMoveRequest,
@@ -23,6 +25,14 @@ from web_backend.services.recommendations import (
     is_completion_column_name,
     sync_project_ticket_to_ml_tables,
 )
+from web_backend.services.inference import predict_ticket_size
+from shared.logging import get_logger
+
+logger = get_logger(__name__)
+
+MANUAL_SIZE_SOURCE = "manual"
+PREDICTED_SIZE_SOURCE = "predicted"
+SIZE_RECOMPUTE_FIELDS = {"title", "description", "labels", "type"}
 
 
 # ------------------------------------------------------------------ #
@@ -102,6 +112,112 @@ async def _get_next_position(
     return max_pos + 1
 
 
+def _assign_manual_size(ticket: ProjectTicket, size_bucket: str | None) -> None:
+    """Persist a user-provided size override on a ticket.
+
+    Args:
+        ticket: Ticket being modified.
+        size_bucket: Explicit size bucket. ``None`` clears any stored size so the
+            backend can fall back to prediction.
+    """
+    if size_bucket is None:
+        ticket.size_bucket = None
+        ticket.size_source = None
+        ticket.size_confidence = None
+        ticket.size_updated_at = None
+        return
+
+    ticket.size_bucket = size_bucket
+    ticket.size_source = MANUAL_SIZE_SOURCE
+    ticket.size_confidence = None
+    ticket.size_updated_at = datetime.now(UTC)
+
+
+def _build_ticket_prediction_request(
+    project: Project,
+    ticket: ProjectTicket,
+    *,
+    rail: str,
+) -> TicketSizePredictionRequest:
+    """Convert a project ticket into the serving payload shape.
+
+    Args:
+        project: Project that owns the ticket.
+        ticket: Ticket to classify.
+        rail: Logical serving rail label for inference telemetry.
+
+    Returns:
+        TicketSizePredictionRequest for the production classifier.
+    """
+    assigned_at = ticket.updated_at if ticket.assignee_id is not None else None
+    return TicketSizePredictionRequest(
+        title=ticket.title,
+        body=ticket.description or "",
+        repo=project.slug,
+        issue_type=ticket.type,
+        labels=[str(label) for label in (ticket.labels or [])],
+        comments_count=0,
+        historical_avg_completion_hours=0.0,
+        created_at=ticket.created_at,
+        assigned_at=assigned_at,
+        rail=rail,
+    )
+
+
+async def _predict_and_persist_ticket_size(
+    db: AsyncSession,
+    *,
+    project: Project,
+    ticket: ProjectTicket,
+    rail: str,
+) -> bool:
+    """Infer and store a ticket size without breaking the main request path.
+
+    Args:
+        db: Active async database session.
+        project: Project that owns the ticket.
+        ticket: Ticket to classify.
+        rail: Serving telemetry rail label.
+
+    Returns:
+        ``True`` when a prediction was stored, otherwise ``False``.
+    """
+    project_slug = project.slug
+    ticket_key = ticket.ticket_key
+
+    try:
+        prediction = await predict_ticket_size(
+            db,
+            _build_ticket_prediction_request(project, ticket, rail=rail),
+        )
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "Failed to predict ticket size for project=%s ticket=%s",
+            project_slug,
+            ticket_key,
+        )
+        return False
+
+    ticket.size_bucket = prediction.predicted_bucket
+    ticket.size_source = PREDICTED_SIZE_SOURCE
+    ticket.size_confidence = prediction.confidence
+    ticket.size_updated_at = datetime.now(UTC)
+
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "Failed to persist predicted ticket size for project=%s ticket=%s",
+            project_slug,
+            ticket_key,
+        )
+        return False
+
+    return True
+
+
 # ------------------------------------------------------------------ #
 #  Create ticket
 # ------------------------------------------------------------------ #
@@ -159,6 +275,9 @@ async def create_ticket(
         priority=data.priority,
         type=data.type,
         labels=data.labels,
+        size_bucket=data.size_bucket,
+        size_source=MANUAL_SIZE_SOURCE if data.size_bucket is not None else None,
+        size_updated_at=datetime.now(UTC) if data.size_bucket is not None else None,
         due_date=data.due_date,
         position=position,
     )
@@ -168,8 +287,17 @@ async def create_ticket(
     await sync_project_ticket_to_ml_tables(db, project, ticket, destination_column)
     await db.commit()
 
-    # Reload with relationships
-    return await _get_ticket_loaded(db, ticket.id)
+    ticket = await _get_ticket_loaded(db, ticket.id)
+    ticket_id = ticket.id
+    if ticket.size_bucket is None:
+        await _predict_and_persist_ticket_size(
+            db,
+            project=project,
+            ticket=ticket,
+            rail="board_ticket_create",
+        )
+
+    return await _get_ticket_loaded(db, ticket_id)
 
 
 # ------------------------------------------------------------------ #
@@ -295,6 +423,10 @@ async def update_ticket(
 
     # Apply updates
     update_fields = data.model_dump(exclude_unset=True)
+    manual_size_provided = "size_bucket" in data.model_fields_set
+    requested_size = update_fields.pop("size_bucket", None)
+    recompute_prediction = bool(SIZE_RECOMPUTE_FIELDS.intersection(update_fields))
+
     for field, value in update_fields.items():
         setattr(ticket, field, value)
 
@@ -306,7 +438,74 @@ async def update_ticket(
     current_column = column_result.scalar_one()
     await sync_project_ticket_to_ml_tables(db, project, ticket, current_column)
     await db.commit()
-    return await _get_ticket_loaded(db, ticket.id)
+
+    ticket = await _get_ticket_loaded(db, ticket.id)
+    ticket_id = ticket.id
+
+    if manual_size_provided:
+        _assign_manual_size(ticket, requested_size)
+        await db.commit()
+        ticket = await _get_ticket_loaded(db, ticket.id)
+        if requested_size is None:
+            await _predict_and_persist_ticket_size(
+                db,
+                project=project,
+                ticket=ticket,
+                rail="board_ticket_update",
+            )
+            return await _get_ticket_loaded(db, ticket_id)
+
+    if ticket.size_source != MANUAL_SIZE_SOURCE and (
+        ticket.size_bucket is None or recompute_prediction
+    ):
+        await _predict_and_persist_ticket_size(
+            db,
+            project=project,
+            ticket=ticket,
+            rail="board_ticket_update",
+        )
+
+    return await _get_ticket_loaded(db, ticket_id)
+
+
+# ------------------------------------------------------------------ #
+#  Batch classify unsized tickets
+# ------------------------------------------------------------------ #
+
+
+async def classify_missing_ticket_sizes(
+    db: AsyncSession,
+    slug: str,
+    user_id: uuid.UUID,
+) -> tuple[int, list[ProjectTicket]]:
+    """Classify and persist any unsized tickets for a project."""
+    project = await _get_project_by_slug(db, slug)
+    await _verify_membership(db, project.id, user_id)
+
+    result = await db.execute(
+        select(ProjectTicket)
+        .where(
+            ProjectTicket.project_id == project.id,
+            ProjectTicket.size_bucket.is_(None),
+        )
+        .options(selectinload(ProjectTicket.assignee))
+        .order_by(ProjectTicket.position)
+    )
+    tickets = list(result.scalars().all())
+
+    updated_count = 0
+    for ticket in tickets:
+        updated_count += int(
+            await _predict_and_persist_ticket_size(
+                db,
+                project=project,
+                ticket=ticket,
+                rail="board_ticket_batch",
+            )
+        )
+
+    refreshed_tickets = await get_board_tickets(db, slug, user_id)
+    return updated_count, refreshed_tickets
 
 
 # ------------------------------------------------------------------ #

--- a/apps/web-frontend/src/components/projects/board/board-card.tsx
+++ b/apps/web-frontend/src/components/projects/board/board-card.tsx
@@ -16,6 +16,7 @@ export interface TicketData {
   type: "task" | "story" | "bug";
   priority: "low" | "medium" | "high" | "critical";
   labels: string[];
+  sizeBucket?: string;
   assignee?: {
     initials: string;
     name: string;
@@ -96,6 +97,15 @@ export function BoardCard({ ticket, index, onClick }: BoardCardProps) {
           <p className="text-[13px] font-medium leading-snug text-foreground">
             {ticket.title}
           </p>
+
+          {ticket.sizeBucket && (
+            <div className="mt-2 inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5">
+              <span className="text-[10px] font-semibold text-primary">
+                {ticket.sizeBucket}
+              </span>
+              <span className="text-[10px] text-muted-foreground">AI size</span>
+            </div>
+          )}
 
           {/* Due date */}
           {ticket.dueDate && (

--- a/apps/web-frontend/src/components/projects/board/board-view.tsx
+++ b/apps/web-frontend/src/components/projects/board/board-view.tsx
@@ -12,6 +12,7 @@ import {
   type BoardColumn as ApiBoardColumn,
   type ProjectMember,
   type TicketResponse,
+  classifyMissingTicketSizes,
   getBoardTickets,
   createTicket as apiCreateTicket,
   moveTicket as apiMoveTicket,
@@ -50,6 +51,7 @@ function apiTicketToCard(
     type: t.type as TicketData["type"],
     priority: t.priority as TicketData["priority"],
     labels: t.labels || [],
+    sizeBucket: t.size_bucket || undefined,
     dueDate: t.due_date
       ? new Date(t.due_date + "T00:00:00").toLocaleDateString("en-US", {
           month: "short",
@@ -132,6 +134,23 @@ export function BoardView({
       if (data) {
         setRawTickets(data.tickets);
         setColumns(buildColumns(boardColumns, data.tickets, memberIndex));
+
+        if (data.tickets.some((ticket) => !ticket.size_bucket)) {
+          const sized = await classifyMissingTicketSizes(token, projectSlug);
+          if (sized.data) {
+            setRawTickets(sized.data.tickets);
+            setColumns(
+              buildColumns(boardColumns, sized.data.tickets, memberIndex)
+            );
+            if (sized.data.updated_count > 0) {
+              toast.success(
+                `AI sized ${sized.data.updated_count} ticket${
+                  sized.data.updated_count === 1 ? "" : "s"
+                }`
+              );
+            }
+          }
+        }
       }
       setIsLoading(false);
     }

--- a/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
+++ b/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
@@ -66,6 +66,14 @@ const typeOptions = [
   { value: "bug", label: "Bug", icon: AlertTriangle, color: "text-red-500" },
 ];
 
+const sizeOptions = [
+  { value: "auto", label: "Auto (AI estimate)" },
+  { value: "S", label: "S" },
+  { value: "M", label: "M" },
+  { value: "L", label: "L" },
+  { value: "XL", label: "XL" },
+];
+
 const COMMON_LABELS = [
   "frontend",
   "backend",
@@ -121,6 +129,11 @@ function TicketDetailEditor({
   const [description, setDescription] = useState(ticket.description || "");
   const [priority, setPriority] = useState(ticket.priority);
   const [type, setType] = useState(ticket.type);
+  const [sizeMode, setSizeMode] = useState(
+    ticket.size_source === "manual" && ticket.size_bucket
+      ? ticket.size_bucket
+      : "auto"
+  );
   const [assigneeId, setAssigneeId] = useState<string | null>(
     ticket.assignee?.id || null
   );
@@ -176,6 +189,7 @@ function TicketDetailEditor({
         description: description.trim() || undefined,
         priority,
         type,
+        size_bucket: sizeMode === "auto" ? null : sizeMode,
         assignee_id: assigneeId,
         due_date: dueDate || undefined,
         labels,
@@ -202,6 +216,7 @@ function TicketDetailEditor({
     description,
     priority,
     type,
+    sizeMode,
     assigneeId,
     dueDate,
     labels,
@@ -249,6 +264,16 @@ function TicketDetailEditor({
 
   const currentType = typeOptions.find((t) => t.value === type);
   const TypeIcon = currentType?.icon || CheckSquare;
+  const sizeMeta =
+    ticket.size_bucket === null
+      ? "No saved size yet. Save with Auto to let the model estimate it."
+      : ticket.size_source === "manual"
+        ? `Manual size override: ${ticket.size_bucket}`
+        : `AI estimate: ${ticket.size_bucket}${
+            ticket.size_confidence !== null
+              ? ` (${Math.round(ticket.size_confidence * 100)}% confidence)`
+              : ""
+          }`;
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
@@ -293,6 +318,34 @@ function TicketDetailEditor({
                 placeholder="Add a description..."
                 className="min-h-[120px] w-full resize-none rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
               />
+            </div>
+
+            {/* Ticket size */}
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">
+                Ticket size
+              </Label>
+              <div className="space-y-2">
+                <Select value={sizeMode} onValueChange={setSizeMode}>
+                  <SelectTrigger className="h-8 text-xs">
+                    <SelectValue placeholder="Choose ticket size" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sizeOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <div className="flex items-center gap-2">
+                  {ticket.size_bucket && (
+                    <Badge variant="secondary">{ticket.size_bucket}</Badge>
+                  )}
+                  <p className="text-xs text-muted-foreground">{sizeMeta}</p>
+                </div>
+              </div>
             </div>
 
             {/* Labels */}

--- a/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
+++ b/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
@@ -186,12 +186,12 @@ function TicketDetailEditor({
       ticket.ticket_key,
       {
         title: title.trim(),
-        description: description.trim() || undefined,
+        description: description.trim() || null,
         priority,
         type,
         size_bucket: sizeMode === "auto" ? null : sizeMode,
         assignee_id: assigneeId,
-        due_date: dueDate || undefined,
+        due_date: dueDate || null,
         labels,
       }
     );

--- a/apps/web-frontend/src/lib/api.ts
+++ b/apps/web-frontend/src/lib/api.ts
@@ -98,6 +98,10 @@ export interface TicketResponse {
   priority: string;
   type: string;
   labels: string[];
+  size_bucket: string | null;
+  size_source: string | null;
+  size_confidence: number | null;
+  size_updated_at: string | null;
   due_date: string | null;
   position: number;
   assignee: TicketAssigneeResponse | null;
@@ -167,6 +171,11 @@ export interface ResumeProfileUploadResponse
   action: string;
 }
 
+export interface TicketBatchSizingResponse {
+  updated_count: number;
+  tickets: TicketResponse[];
+}
+
 export interface SigninRequest {
   login: string;
   password: string;
@@ -198,22 +207,24 @@ export interface UpdateMemberRoleRequest {
 
 export interface TicketCreateRequest {
   title: string;
-  description?: string;
+  description?: string | null;
   column_id: string;
   priority?: string;
   type?: string;
   labels?: string[];
-  due_date?: string;
+  size_bucket?: string | null;
+  due_date?: string | null;
   assignee_id?: string | null;
 }
 
 export interface TicketUpdateRequest {
   title?: string;
-  description?: string;
+  description?: string | null;
   priority?: string;
   type?: string;
   labels?: string[];
-  due_date?: string;
+  size_bucket?: string | null;
+  due_date?: string | null;
   assignee_id?: string | null;
 }
 
@@ -443,6 +454,16 @@ export function getBoardTickets(token: string, slug: string) {
     method: "GET",
     token,
   });
+}
+
+export function classifyMissingTicketSizes(token: string, slug: string) {
+  return request<TicketBatchSizingResponse>(
+    `/api/v1/projects/${slug}/tickets/classify-missing`,
+    {
+      method: "POST",
+      token,
+    }
+  );
 }
 
 export function createTicket(

--- a/scripts/postgres/init/05_project_tickets.sql
+++ b/scripts/postgres/init/05_project_tickets.sql
@@ -48,6 +48,10 @@ CREATE TABLE IF NOT EXISTS project_tickets (
     priority     ticket_priority  NOT NULL DEFAULT 'medium',
     type         ticket_type      NOT NULL DEFAULT 'task',
     labels       JSONB            NOT NULL DEFAULT '[]',
+    size_bucket  VARCHAR(16),
+    size_source  VARCHAR(16),
+    size_confidence DOUBLE PRECISION,
+    size_updated_at TIMESTAMPTZ,
     due_date     DATE,
     position     INTEGER          NOT NULL DEFAULT 0,
 
@@ -56,6 +60,18 @@ CREATE TABLE IF NOT EXISTS project_tickets (
 
     CONSTRAINT uq_project_tickets_key UNIQUE (project_id, ticket_key)
 );
+
+ALTER TABLE IF EXISTS project_tickets
+    ADD COLUMN IF NOT EXISTS size_bucket VARCHAR(16);
+
+ALTER TABLE IF EXISTS project_tickets
+    ADD COLUMN IF NOT EXISTS size_source VARCHAR(16);
+
+ALTER TABLE IF EXISTS project_tickets
+    ADD COLUMN IF NOT EXISTS size_confidence DOUBLE PRECISION;
+
+ALTER TABLE IF EXISTS project_tickets
+    ADD COLUMN IF NOT EXISTS size_updated_at TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_project_tickets_project_id
     ON project_tickets (project_id);


### PR DESCRIPTION
## What changed
- persist ticket sizing metadata on project tickets (`size_bucket`, `size_source`, `size_confidence`, `size_updated_at`)
- auto-run size prediction on ticket create/update unless a manual size is set
- allow clearing manual size back to automatic sizing
- add a backend endpoint to backfill size predictions for legacy unsized tickets
- surface sizing state in the project board UI and ticket detail modal

## Why
Ticket #121 needs the classification model to be used in a real board workflow instead of existing only as an offline pipeline. This wires the model into project tickets in a way that works for both new and existing tickets while still allowing manual override by the user.

## Validation
- `just pytest apps/web-backend/tests/test_ticket_sizing.py apps/web-backend/tests/test_inference.py`
- `just pylint apps/web-backend/web_backend/api/v1/tickets.py apps/web-backend/web_backend/models/ticket.py apps/web-backend/web_backend/schemas/tickets.py apps/web-backend/web_backend/services/tickets.py apps/web-backend/tests/test_ticket_sizing.py`
- `npm --prefix apps/web-frontend run typecheck`
- `npm --prefix apps/web-frontend run build`