### PR TITLE
fix: avoid Model CI promotion failure on large MLflow uploads

### DIFF
--- a/apps/training/tests/test_mlflow_tracking.py
+++ b/apps/training/tests/test_mlflow_tracking.py
@@ -304,6 +304,78 @@ class TestLogRunToMlflow:
 
 
 # ---------------------------------------------------------------------------
+# _load_and_register
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAndRegister:
+  def test_prefers_existing_logged_artifact_registration(self, tmp_path: Path) -> None:
+    from training.analysis.mlflow_tracking import _load_and_register
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _make_grid_pickle(run_dir, "forest")
+
+    with (
+      patch(
+        "training.analysis.mlflow_tracking._register_logged_best_estimator",
+        return_value=True,
+      ) as mock_logged_register,
+      patch("training.analysis.mlflow_tracking._register_model") as mock_register_model,
+    ):
+      result = _load_and_register(
+        run_dir=run_dir,
+        best_model_name="forest",
+        run_id="run-1",
+        candidate_metrics={},
+        client=MagicMock(),
+      )
+
+    assert result is True
+    mock_logged_register.assert_called_once()
+    mock_register_model.assert_not_called()
+
+  def test_falls_back_to_local_upload_when_logged_artifact_missing(
+    self, tmp_path: Path
+  ) -> None:
+    from training.analysis.mlflow_tracking import _load_and_register
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _make_grid_pickle(run_dir, "forest")
+
+    fake_grid = MagicMock()
+    fake_grid.best_estimator_ = object()
+
+    with (
+      patch(
+        "training.analysis.mlflow_tracking._register_logged_best_estimator",
+        return_value=False,
+      ),
+      patch("training.analysis.mlflow_tracking.joblib.load", return_value=fake_grid),
+      patch(
+        "training.analysis.mlflow_tracking._register_model",
+        return_value=True,
+      ) as mock_register_model,
+    ):
+      result = _load_and_register(
+        run_dir=run_dir,
+        best_model_name="forest",
+        run_id="run-2",
+        candidate_metrics={"accuracy": 0.8},
+        client=MagicMock(),
+      )
+
+    assert result is True
+    mock_register_model.assert_called_once_with(
+      fake_grid.best_estimator_,
+      "forest",
+      "run-2",
+      {"accuracy": 0.8},
+    )
+
+
+# ---------------------------------------------------------------------------
 # promote_best_model
 # ---------------------------------------------------------------------------
 

--- a/apps/training/training/analysis/mlflow_tracking.py
+++ b/apps/training/training/analysis/mlflow_tracking.py
@@ -332,6 +332,82 @@ def _register_model(
   return True
 
 
+def _register_logged_best_estimator(
+  client: MlflowClient,
+  run_id: str,
+  best_model_name: str,
+) -> bool:
+  """Register using an already-logged run artifact to avoid re-uploading.
+
+  This path avoids large single-request uploads through the tracking endpoint
+  (which can hit HTTP 413 on Cloud Run) by creating the model version from the
+  existing ``runs:/.../best_estimator`` artifact.
+  """
+  experiment = mlflow.get_experiment_by_name(_EXPERIMENT_NAME)
+  if experiment is None:
+    logger.info(
+      "MLflow experiment '%s' not found; falling back to local upload",
+      _EXPERIMENT_NAME,
+    )
+    return False
+
+  search_filter = (
+    f"tags.run_id = '{run_id}' and "
+    f"tags.model = '{best_model_name}' and "
+    f"attributes.run_name = 'search_{best_model_name}'"
+  )
+  try:
+    runs = client.search_runs(
+      experiment_ids=[experiment.experiment_id],
+      filter_string=search_filter,
+      order_by=["attributes.start_time DESC"],
+      max_results=1,
+    )
+  except Exception:
+    logger.warning(
+      "Could not search MLflow runs for existing logged model '%s' (run_id=%s)",
+      best_model_name,
+      run_id,
+      exc_info=True,
+    )
+    return False
+
+  if not runs:
+    logger.info(
+      "No logged model run found for '%s' (run_id=%s); falling back to local upload",
+      best_model_name,
+      run_id,
+    )
+    return False
+
+  logged_run_id = getattr(getattr(runs[0], "info", None), "run_id", None)
+  if not logged_run_id:
+    logger.info(
+      (
+        "Logged model run missing run_id for '%s' (run_id=%s); "
+        "falling back to local upload"
+      ),
+      best_model_name,
+      run_id,
+    )
+    return False
+
+  model_uri = f"runs:/{logged_run_id}/best_estimator"
+  try:
+    mlflow.register_model(model_uri=model_uri, name=_REGISTERED_MODEL_NAME)
+  except Exception:
+    logger.warning(
+      "Could not register '%s' from %s; falling back to local upload",
+      best_model_name,
+      model_uri,
+      exc_info=True,
+    )
+    return False
+
+  logger.info("Registered '%s' from existing artifact %s", best_model_name, model_uri)
+  return True
+
+
 def _transition_to_production(client: MlflowClient, new_version: str) -> bool:
   """Archive old Production versions and promote new_version to Production.
 
@@ -387,6 +463,7 @@ def _load_and_register(
   best_model_name: str,
   run_id: str,
   candidate_metrics: dict[str, float],
+  client: MlflowClient,
 ) -> bool:
   """Load the best model pickle and register it in the MLflow Model Registry.
 
@@ -399,6 +476,7 @@ def _load_and_register(
       best_model_name:  Model name used to locate ``{model}.pkl``.
       run_id:           Training run identifier (logged as an MLflow tag).
       candidate_metrics: Candidate eval metrics logged during registration.
+      client:           MLflow tracking client.
 
   Returns:
       True if loading and registration both succeeded, False otherwise.
@@ -407,6 +485,12 @@ def _load_and_register(
   if not pkl_path.exists():
     logger.warning("Model pickle not found at %s — cannot promote", pkl_path)
     return False
+
+  # Prefer model registration from an already-logged artifact to avoid
+  # large request uploads that can fail behind Cloud Run limits.
+  if _register_logged_best_estimator(client, run_id, best_model_name):
+    return True
+
   try:
     grid = joblib.load(pkl_path)
     model = grid.best_estimator_
@@ -567,7 +651,13 @@ def promote_best_model(run_id: str) -> str | None:
           guard_result.get("fail_reasons", []),
         )
       else:
-        loaded = _load_and_register(run_dir, best_model_name, run_id, candidate_metrics)
+        loaded = _load_and_register(
+          run_dir,
+          best_model_name,
+          run_id,
+          candidate_metrics,
+          client,
+        )
         if loaded:
           new_version = _get_new_version(client, best_model_name)
           if new_version is not None and _transition_to_production(client, new_version):


### PR DESCRIPTION
## What this fixes\nModel CI/CD was failing on main during `Train / Run & Promote Best Model` with:\n- `HTTP 413 Request Entity Too Large`\n- failing step: `Run training and gate pipeline`\n- reason surfaced as `promotion-failed`\n\nThe failure happened while re-uploading a large model artifact during registry promotion.\n\n## Changes\n- Added a promotion-first path in `mlflow_tracking.py` that registers the model from the already-logged run artifact (`runs:/<run_id>/best_estimator`) instead of re-uploading the pickle.\n- Kept the existing local-upload registration path as fallback if the logged artifact path is unavailable.\n- Added tests to verify:\n  - existing logged artifact path is preferred\n  - fallback upload path is used when logged artifact registration is unavailable\n\n## Why this is safe\n- No gate-threshold policy changes.\n- No deploy/infra workflow changes.\n- Keeps baseline guardrails and promotion transitions unchanged.\n\n## Local validation\n- `just pylint apps/training/training/analysis/mlflow_tracking.py apps/training/tests/test_mlflow_tracking.py`\n- `just pytest apps/training/tests/test_mlflow_tracking.py apps/training/tests/test_cmd_train_with_gates.py`\n