### PR TITLE
fix: harden mlflow promotion registration URI fallback

### DIFF
--- a/apps/training/tests/test_mlflow_tracking.py
+++ b/apps/training/tests/test_mlflow_tracking.py
@@ -333,7 +333,7 @@ class TestRegisterLoggedBestEstimator:
       name="ticket-forge-best",
     )
 
-  def test_does_not_register_different_model_when_best_candidate_fails(self) -> None:
+  def test_tries_alternate_uri_for_same_best_model_run(self) -> None:
     from training.analysis.mlflow_tracking import _register_logged_best_estimator
 
     bad = MagicMock()
@@ -358,11 +358,69 @@ class TestRegisterLoggedBestEstimator:
       register_model.side_effect = [Exception("missing best_estimator"), None]
       ok = _register_logged_best_estimator(client, "pipeline-2", "random_forest")
 
+    assert ok is True
+    assert register_model.call_args_list == [
+      (
+        (),
+        {
+          "model_uri": "runs:/run-rf/best_estimator",
+          "name": "ticket-forge-best",
+        },
+      ),
+      (
+        (),
+        {
+          "model_uri": "runs:/run-rf/model",
+          "name": "ticket-forge-best",
+        },
+      ),
+    ]
+
+  def test_does_not_register_different_model_when_best_candidate_fails(self) -> None:
+    from training.analysis.mlflow_tracking import _register_logged_best_estimator
+
+    bad = MagicMock()
+    bad.info.run_id = "run-xgb"
+    bad.data.tags = {"model": "xgboost", "mlflow.runName": "search_xgboost"}
+    good = MagicMock()
+    good.info.run_id = "run-rf"
+    good.data.tags = {
+      "model": "random_forest",
+      "mlflow.runName": "search_random_forest",
+    }
+    client = MagicMock()
+    client.search_runs.return_value = [bad, good]
+    exp_lookup = "training.analysis.mlflow_tracking.mlflow.get_experiment_by_name"
+    register_path = "training.analysis.mlflow_tracking.mlflow.register_model"
+
+    with (
+      patch(exp_lookup) as get_exp,
+      patch(register_path) as register_model,
+    ):
+      get_exp.return_value = MagicMock(experiment_id="1")
+      register_model.side_effect = [
+        Exception("missing best_estimator"),
+        Exception("missing fallback model path"),
+      ]
+      ok = _register_logged_best_estimator(client, "pipeline-3", "random_forest")
+
     assert ok is False
-    register_model.assert_called_once_with(
-      model_uri="runs:/run-rf/best_estimator",
-      name="ticket-forge-best",
-    )
+    assert register_model.call_args_list == [
+      (
+        (),
+        {
+          "model_uri": "runs:/run-rf/best_estimator",
+          "name": "ticket-forge-best",
+        },
+      ),
+      (
+        (),
+        {
+          "model_uri": "runs:/run-rf/model",
+          "name": "ticket-forge-best",
+        },
+      ),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/training/training/analysis/mlflow_tracking.py
+++ b/apps/training/training/analysis/mlflow_tracking.py
@@ -91,22 +91,35 @@ def _register_from_candidates(
   best_model_name: str,
 ) -> bool:
   """Try registering from candidate run artifacts in order."""
+
+  def _candidate_model_uris(run_id: str) -> list[str]:
+    # Support both the new explicit name and older/default artifact naming.
+    return [
+      f"runs:/{run_id}/best_estimator",
+      f"runs:/{run_id}/model",
+    ]
+
   for candidate_run_id in candidate_run_ids:
     if not candidate_run_id:
       continue
-    model_uri = f"runs:/{candidate_run_id}/best_estimator"
-    try:
-      mlflow.register_model(model_uri=model_uri, name=_REGISTERED_MODEL_NAME)
-    except Exception:
+    for model_uri in _candidate_model_uris(candidate_run_id):
+      try:
+        mlflow.register_model(model_uri=model_uri, name=_REGISTERED_MODEL_NAME)
+      except Exception as exc:
+        logger.info(
+          "Could not register '%s' from %s (%s), trying next candidate URI",
+          best_model_name,
+          model_uri,
+          type(exc).__name__,
+        )
+        continue
+
       logger.info(
-        "Could not register '%s' from %s, trying next candidate",
+        "Registered '%s' from existing artifact %s",
         best_model_name,
         model_uri,
       )
-      continue
-
-    logger.info("Registered '%s' from existing artifact %s", best_model_name, model_uri)
-    return True
+      return True
   return False
 
 
@@ -260,7 +273,7 @@ def _log_model_run(
         grid = joblib.load(pkl_path)
         mlflow.sklearn.log_model(
           grid.best_estimator_,
-          artifact_path="best_estimator",
+          name="best_estimator",
           registered_model_name=None,
         )
         mlflow.log_params({k: str(v) for k, v in (grid.best_params_ or {}).items()})
@@ -386,7 +399,7 @@ def _register_model(
       mlflow.set_tag("promoted_model", best_model_name)
       mlflow.sklearn.log_model(
         model,
-        artifact_path="model",
+        name="model",
         registered_model_name=_REGISTERED_MODEL_NAME,
       )
       if candidate_metrics:


### PR DESCRIPTION
Model CI/CD still failed after #152 because promotion could fall back to local model upload and hit HTTP 413 again. This patch uses name-based model logging and retries registration from both runs URI variants for the same candidate run before any local upload fallback. It also adds/updates tests covering this fallback behavior and keeps model-safe candidate selection.