### PR TITLE
fix: serialize airflow/model terraform preflight

### DIFF
--- a/.github/workflows/airflow-deploy.yml
+++ b/.github/workflows/airflow-deploy.yml
@@ -244,13 +244,18 @@ jobs:
               --zone="${instance_zone}" \
               --tunnel-through-iap \
               --quiet \
-              --command='cd /opt/ticket-forge && git rev-parse HEAD' 2>/dev/null || true)"
+              --command='cd /opt/ticket-forge && git rev-parse HEAD' 2>/dev/null | tail -n1 | tr -d '\r' || true)"
+            if [[ ! "${runtime_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              runtime_sha=""
+            fi
           fi
 
-          echo "instance_name=${instance_name}" >> "$GITHUB_OUTPUT"
-          echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
-          echo "airflow_url=${airflow_url}" >> "$GITHUB_OUTPUT"
-          echo "runtime_sha=${runtime_sha}" >> "$GITHUB_OUTPUT"
+          {
+            echo "instance_name=${instance_name}"
+            echo "instance_id=${instance_id}"
+            echo "airflow_url=${airflow_url}"
+            echo "runtime_sha=${runtime_sha}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Write deployment report
         if: always()

--- a/.github/workflows/model-cicd.yml
+++ b/.github/workflows/model-cicd.yml
@@ -94,11 +94,57 @@ jobs:
           echo "Timed out waiting for CI/CD test gate on ${SOURCE_SHA}" >&2
           exit 1
 
-  train-and-promote:
-    name: Train / Run & Promote Best Model
+  prepare-infra:
+    name: Train / Prepare Shared Infra Access
     needs: [wait-for-ci]
     if: >-
       (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped') &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch'
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      tracking_uri: ${{ steps.mlflow-ready.outputs.tracking_uri }}
+    concurrency:
+      group: ticketforge-terraform-apply-prod
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER_ID }}
+          service_account: 'tf-apply-sa@${{ secrets.TF_VAR_PROJECT_ID }}.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.TF_VAR_project_id }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init -backend-config="bucket=${TF_VAR_state_bucket}"
+
+      - name: Ensure tf-apply can create runtime service accounts
+        run: bash scripts/ci/ensure_tf_apply_service_account_admin.sh
+
+      - name: Ensure MLflow tracking service is ready
+        id: mlflow-ready
+        run: bash scripts/ci/ensure_mlflow_tracking_ready.sh
+
+  train-and-promote:
+    name: Train / Run & Promote Best Model
+    needs: [wait-for-ci, prepare-infra]
+    if: >-
+      (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped') &&
+      needs.prepare-infra.result == 'success' &&
       (
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
@@ -179,19 +225,6 @@ jobs:
         with:
           project_id: ${{ env.TF_VAR_project_id }}
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform Init
-        run: terraform -chdir=terraform init -backend-config="bucket=${TF_VAR_state_bucket}"
-
-      - name: Ensure tf-apply can create runtime service accounts
-        run: bash scripts/ci/ensure_tf_apply_service_account_admin.sh
-
-      - name: Ensure MLflow tracking service is ready
-        id: mlflow-ready
-        run: bash scripts/ci/ensure_mlflow_tracking_ready.sh
-
       - name: Resolve MLflow tracking credentials
         run: |
           set -euo pipefail
@@ -225,7 +258,7 @@ jobs:
             --promote "$PROMOTE"
         env:
           # Force training/promotion to use the shared remote MLflow service.
-          MLFLOW_TRACKING_URI: ${{ steps.mlflow-ready.outputs.tracking_uri }}
+          MLFLOW_TRACKING_URI: ${{ needs.prepare-infra.outputs.tracking_uri }}
           MLFLOW_TRACKING_URI_FROM_GCP: "false"
           MLFLOW_CLOUD_RUN_SERVICE: "mlflow-tracking"
           MLFLOW_GCP_REGION: ${{ env.TF_VAR_region }}

--- a/.github/workflows/model-cicd.yml
+++ b/.github/workflows/model-cicd.yml
@@ -98,6 +98,7 @@ jobs:
     name: Train / Prepare Shared Infra Access
     needs: [wait-for-ci]
     if: >-
+      always() &&
       (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped') &&
       (
         github.event_name == 'push' ||
@@ -143,6 +144,7 @@ jobs:
     name: Train / Run & Promote Best Model
     needs: [wait-for-ci, prepare-infra]
     if: >-
+      always() &&
       (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped') &&
       needs.prepare-infra.result == 'success' &&
       (


### PR DESCRIPTION
## What changed
- move the short Terraform/MLflow preflight in Model CI/CD into a separate `prepare-infra` job
- serialize that job with Airflow/serving deploys via the shared `ticketforge-terraform-apply-prod` concurrency group
- keep training itself outside the lock so long model runs do not block deploy workflows
- harden Airflow deployment metadata collection so noisy `gcloud compute ssh` output cannot corrupt `GITHUB_OUTPUT`
- allow manual/scheduled Model CI/CD runs to reach `prepare-infra` by using `always()` on the job conditions

## Why
The failing main Airflow run for `#154` showed two separate workflow issues:
1. Airflow deploy collided with the Model CI/CD Terraform preflight and failed to acquire the shared Terraform state lock.
2. Airflow metadata collection could fail even after deploy because SSH noise like `Your identification has been saved ...` was being echoed into `GITHUB_OUTPUT`.

## Validation
### Local
- `just pytest apps/training/tests/test_mlflow_tracking.py apps/training/tests/test_cmd_train_with_gates.py`
- `just pylint apps/training/training/analysis/mlflow_tracking.py apps/training/tests/test_mlflow_tracking.py`
- `bash -n scripts/ci/ensure_tf_apply_service_account_admin.sh`
- YAML parse checks for `.github/workflows/model-cicd.yml` and `.github/workflows/airflow-deploy.yml`
- `git diff --check`

### Live branch validation
- Manual Airflow Deploy on this branch (`run 24259822142`) cleared `Deploy Airflow VM and runtime secrets` without the previous Terraform lock collision.
- A concurrent manual Model CI/CD run on this branch (`run 24259928500`) reached `Train / Prepare Shared Infra Access` and queued behind the Airflow run instead of racing it for Terraform state.

I left this draft while the branch Airflow run finishes through the remaining smoke-test/reporting tail, but the lock-race behavior is already validated.
