### PR TITLE
fix: complete ticket #121 auto sizing flow

### DIFF
--- a/apps/web-backend/tests/conftest.py
+++ b/apps/web-backend/tests/conftest.py
@@ -4,90 +4,87 @@ Uses an async in-memory SQLite database so tests never
 require a running Postgres instance.
 """
 
-collect_ignore = [
-  "test_airflow_service.py",
-  "test_coldstart_router.py",
-  "test_ticket_sizing.py",
-  "test_recommendations.py",
-]
-
 import asyncio
 from collections.abc import AsyncGenerator
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import (
-  AsyncSession,
-  async_sessionmaker,
-  create_async_engine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
 )
 
 from web_backend.database import get_db
 from web_backend.main import app
 from web_backend.models.base import Base
 
+collect_ignore = [
+    "test_airflow_service.py",
+    "test_coldstart_router.py",
+]
 
 
 @pytest.fixture(scope="session")
 def event_loop():
-  """Create a single event loop for the entire test session."""
-  loop = asyncio.new_event_loop()
-  yield loop
-  loop.close()
+    """Create a single event loop for the entire test session."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
 
 
 @pytest.fixture()
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
-  """Yield a fresh async DB session backed by in-memory SQLite.
+    """Yield a fresh async DB session backed by in-memory SQLite.
 
-  Tables are created before each test and dropped after,
-  giving every test a clean slate.
-  """
-  engine = create_async_engine(
-    "sqlite+aiosqlite:///:memory:",
-    echo=False,
-  )
+    Tables are created before each test and dropped after,
+    giving every test a clean slate.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+    )
 
-  async with engine.begin() as conn:
-    await conn.run_sync(Base.metadata.create_all)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
 
-  session_factory = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-  )
+    session_factory = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
 
-  async with session_factory() as session:
-    yield session
+    async with session_factory() as session:
+        yield session
 
-  async with engine.begin() as conn:
-    await conn.run_sync(Base.metadata.drop_all)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
 
-  await engine.dispose()
+    await engine.dispose()
 
 
 @pytest.fixture()
 async def client(
-  db_session: AsyncSession,
+    db_session: AsyncSession,
 ) -> AsyncGenerator[AsyncClient, None]:
-  """Yield an httpx AsyncClient wired to the FastAPI app.
+    """Yield an httpx AsyncClient wired to the FastAPI app.
 
-  Overrides the ``get_db`` dependency so all routes use the
-  in-memory test database instead of Postgres.
-  """
+    Overrides the ``get_db`` dependency so all routes use the
+    in-memory test database instead of Postgres.
+    """
 
-  async def _override_get_db() -> AsyncGenerator[AsyncSession, None]:
-    yield db_session
+    async def _override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
 
-  app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_db] = _override_get_db
 
-  async with AsyncClient(
-    transport=ASGITransport(app=app),
-    base_url="http://test",
-  ) as ac:
-    yield ac
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
 
-  app.dependency_overrides.clear()
+    app.dependency_overrides.clear()
 
 
 # ------------------------------------------------------------------ #
@@ -95,17 +92,17 @@ async def client(
 # ------------------------------------------------------------------ #
 
 VALID_SIGNUP = {
-  "username": "johndoe",
-  "first_name": "John",
-  "last_name": "Doe",
-  "email": "john@example.com",
-  "password": "SecurePass1",
+    "username": "johndoe",
+    "first_name": "John",
+    "last_name": "Doe",
+    "email": "john@example.com",
+    "password": "SecurePass1",
 }
 
 VALID_SIGNUP_2 = {
-  "username": "janedoe",
-  "first_name": "Jane",
-  "last_name": "Doe",
-  "email": "jane@example.com",
-  "password": "SecurePass1",
+    "username": "janedoe",
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "email": "jane@example.com",
+    "password": "SecurePass1",
 }

--- a/apps/web-backend/tests/test_ticket_sizing.py
+++ b/apps/web-backend/tests/test_ticket_sizing.py
@@ -111,6 +111,29 @@ async def test_manual_ticket_size_skips_reprediction_on_update(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_legacy_size_field_maps_to_manual_size_bucket(client) -> None:
+    """Legacy `size` payloads should still persist a manual size bucket."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    create_response = await client.post(
+        f"/api/v1/projects/{project['slug']}/tickets",
+        headers=headers,
+        json={
+            "title": "Legacy size ticket",
+            "column_id": column_id,
+            "size": "L",
+        },
+    )
+
+    assert create_response.status_code == 201
+    payload = create_response.json()
+    assert payload["size_bucket"] == "L"
+    assert payload["size_source"] == "manual"
+
+
+@pytest.mark.asyncio
 async def test_clearing_manual_size_recomputes_prediction(client) -> None:
     """Switching back to auto mode should recompute and persist an AI size."""
     headers = await _auth_headers(client)
@@ -145,6 +168,45 @@ async def test_clearing_manual_size_recomputes_prediction(client) -> None:
     assert payload["size_bucket"] == "XL"
     assert payload["size_source"] == "predicted"
     assert payload["size_confidence"] == 0.66
+
+
+@pytest.mark.asyncio
+async def test_legacy_size_update_sets_manual_size_bucket(client) -> None:
+    """Legacy `size` updates should map to manual size and skip prediction."""
+    headers = await _auth_headers(client)
+    project = await _create_project(client, headers)
+    column_id = project["board_columns"][0]["id"]
+
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(
+            return_value=SimpleNamespace(predicted_bucket="M", confidence=0.77)
+        ),
+    ):
+        create_response = await client.post(
+            f"/api/v1/projects/{project['slug']}/tickets",
+            headers=headers,
+            json={"title": "Legacy update size ticket", "column_id": column_id},
+        )
+
+    assert create_response.status_code == 201
+    ticket_key = create_response.json()["ticket_key"]
+
+    with patch(
+        "web_backend.services.tickets.predict_ticket_size",
+        new=AsyncMock(),
+    ) as mock_predict:
+        response = await client.patch(
+            f"/api/v1/projects/{project['slug']}/tickets/{ticket_key}",
+            headers=headers,
+            json={"size": "XL"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["size_bucket"] == "XL"
+    assert payload["size_source"] == "manual"
+    mock_predict.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/apps/web-backend/web_backend/api/v1/tickets.py
+++ b/apps/web-backend/web_backend/api/v1/tickets.py
@@ -11,6 +11,7 @@ from web_backend.database import get_db
 from web_backend.models.user import AuthUser
 from web_backend.schemas.tickets import (
     BoardTicketsResponse,
+    TicketBatchSizingResponse,
     TicketAssigneeResponse,
     TicketCreateRequest,
     TicketMoveRequest,
@@ -19,6 +20,7 @@ from web_backend.schemas.tickets import (
 )
 from web_backend.security.dependencies import get_current_user
 from web_backend.services.tickets import (
+    classify_missing_ticket_sizes,
     create_ticket,
     delete_ticket,
     get_board_tickets,
@@ -28,6 +30,11 @@ from web_backend.services.tickets import (
 )
 
 router = APIRouter(prefix="/projects/{slug}/tickets", tags=["Tickets"])
+
+
+# ------------------------------------------------------------------ #
+#  Helper: build TicketResponse from ORM
+# ------------------------------------------------------------------ #
 
 
 def _ticket_to_response(ticket) -> TicketResponse:
@@ -50,8 +57,12 @@ def _ticket_to_response(ticket) -> TicketResponse:
         description=ticket.description,
         priority=ticket.priority,
         type=ticket.type,
-        size=ticket.size,
         labels=ticket.labels,
+        size=ticket.size_bucket,
+        size_bucket=ticket.size_bucket,
+        size_source=ticket.size_source,
+        size_confidence=ticket.size_confidence,
+        size_updated_at=ticket.size_updated_at,
         due_date=ticket.due_date,
         position=ticket.position,
         assignee=assignee,
@@ -61,31 +72,90 @@ def _ticket_to_response(ticket) -> TicketResponse:
     )
 
 
+# ------------------------------------------------------------------ #
+#  GET /projects/:slug/tickets — all tickets for board
+# ------------------------------------------------------------------ #
+
+
 @router.get("", response_model=BoardTicketsResponse)
 async def list_board_tickets(
     slug: str,
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> BoardTicketsResponse:
+    """Get all tickets for a project board."""
     try:
         tickets = await get_board_tickets(db, slug, current_user.id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
     return BoardTicketsResponse(tickets=[_ticket_to_response(t) for t in tickets])
 
 
-@router.post("", response_model=TicketResponse, status_code=status.HTTP_201_CREATED)
+# ------------------------------------------------------------------ #
+#  POST /projects/:slug/tickets — create ticket
+# ------------------------------------------------------------------ #
+
+
+@router.post(
+    "",
+    response_model=TicketResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_ticket_endpoint(
     slug: str,
     data: TicketCreateRequest,
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> TicketResponse:
+    """Create a new ticket on the board."""
     try:
         ticket = await create_ticket(db, slug, data, current_user)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
     return _ticket_to_response(ticket)
+
+
+# ------------------------------------------------------------------ #
+#  POST /projects/:slug/tickets/classify-missing — backfill AI sizes
+# ------------------------------------------------------------------ #
+
+
+@router.post("/classify-missing", response_model=TicketBatchSizingResponse)
+async def classify_missing_ticket_sizes_endpoint(
+    slug: str,
+    current_user: AuthUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TicketBatchSizingResponse:
+    """Classify and persist any tickets that do not have a stored size."""
+    try:
+        updated_count, tickets = await classify_missing_ticket_sizes(
+            db,
+            slug,
+            current_user.id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+    return TicketBatchSizingResponse(
+        updated_count=updated_count,
+        tickets=[_ticket_to_response(ticket) for ticket in tickets],
+    )
+
+
+# ------------------------------------------------------------------ #
+#  GET /projects/:slug/tickets/:ticket_key — single ticket
+# ------------------------------------------------------------------ #
 
 
 @router.get("/{ticket_key}", response_model=TicketResponse)
@@ -95,11 +165,21 @@ async def get_ticket_endpoint(
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> TicketResponse:
+    """Get a single ticket by its key."""
     try:
         ticket = await get_ticket_by_key(db, slug, ticket_key, current_user.id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
     return _ticket_to_response(ticket)
+
+
+# ------------------------------------------------------------------ #
+#  PATCH /projects/:slug/tickets/:ticket_key — update ticket
+# ------------------------------------------------------------------ #
 
 
 @router.patch("/{ticket_key}", response_model=TicketResponse)
@@ -110,11 +190,21 @@ async def update_ticket_endpoint(
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> TicketResponse:
+    """Update a ticket's fields."""
     try:
         ticket = await update_ticket(db, slug, ticket_key, data, current_user.id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
     return _ticket_to_response(ticket)
+
+
+# ------------------------------------------------------------------ #
+#  PATCH /projects/:slug/tickets/:ticket_key/move — drag-and-drop
+# ------------------------------------------------------------------ #
 
 
 @router.patch("/{ticket_key}/move", response_model=TicketResponse)
@@ -125,11 +215,21 @@ async def move_ticket_endpoint(
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> TicketResponse:
+    """Move a ticket to a different column/position (drag-and-drop)."""
     try:
         ticket = await move_ticket(db, slug, ticket_key, data, current_user.id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
     return _ticket_to_response(ticket)
+
+
+# ------------------------------------------------------------------ #
+#  DELETE /projects/:slug/tickets/:ticket_key — delete ticket
+# ------------------------------------------------------------------ #
 
 
 @router.delete("/{ticket_key}", status_code=status.HTTP_204_NO_CONTENT)
@@ -139,7 +239,11 @@ async def delete_ticket_endpoint(
     current_user: AuthUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
+    """Delete a ticket."""
     try:
         await delete_ticket(db, slug, ticket_key, current_user.id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc

--- a/apps/web-backend/web_backend/models/ticket.py
+++ b/apps/web-backend/web_backend/models/ticket.py
@@ -1,11 +1,16 @@
 """Project ticket ORM models."""
 
+# Pylint doesn't fully understand SQLAlchemy's `Mapped[...]` generic.
+# pylint: disable=unsubscriptable-object
+
 import uuid
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import (
     Date,
+    DateTime,
     Enum,
+    Float,
     ForeignKey,
     Integer,
     JSON,
@@ -37,9 +42,7 @@ class ProjectTicket(TimestampMixin, Base):
 
     __tablename__ = "project_tickets"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        Uuid, primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(
         Uuid,
         ForeignKey("projects.id", ondelete="CASCADE"),
@@ -68,7 +71,14 @@ class ProjectTicket(TimestampMixin, Base):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     priority: Mapped[str] = mapped_column(
-        Enum("low", "medium", "high", "critical", name="ticket_priority", create_type=False),
+        Enum(
+            "low",
+            "medium",
+            "high",
+            "critical",
+            name="ticket_priority",
+            create_type=False,
+        ),
         nullable=False,
         default="medium",
     )
@@ -77,12 +87,14 @@ class ProjectTicket(TimestampMixin, Base):
         nullable=False,
         default="task",
     )
-    size: Mapped[str] = mapped_column(
-        Enum("S", "M", "L", "XL", name="ticket_size", create_type=False),
-        nullable=False,
-        default="M",
-    )
     labels: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    size_bucket: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    size_source: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    size_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    size_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
     due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/apps/web-backend/web_backend/schemas/tickets.py
+++ b/apps/web-backend/web_backend/schemas/tickets.py
@@ -19,8 +19,9 @@ class TicketCreateRequest(BaseModel):
     column_id: uuid.UUID
     priority: str = Field(default="medium", pattern="^(low|medium|high|critical)$")
     type: str = Field(default="task", pattern="^(task|story|bug)$")
-    size: str = Field(default="M", pattern="^(S|M|L|XL)$")
-    labels: list[str] = Field(default=[])
+    labels: list[str] = Field(default_factory=list)
+    size: str | None = Field(None, pattern="^(S|M|L|XL)$")
+    size_bucket: str | None = Field(None, pattern="^(S|M|L|XL)$")
     due_date: date | None = None
     assignee_id: uuid.UUID | None = None
 
@@ -37,8 +38,9 @@ class TicketUpdateRequest(BaseModel):
     description: str | None = Field(None, max_length=5000)
     priority: str | None = Field(None, pattern="^(low|medium|high|critical)$")
     type: str | None = Field(None, pattern="^(task|story|bug)$")
-    size: str | None = Field(None, pattern="^(S|M|L|XL)$")
     labels: list[str] | None = None
+    size: str | None = Field(None, pattern="^(S|M|L|XL)$")
+    size_bucket: str | None = Field(None, pattern="^(S|M|L|XL)$")
     due_date: date | None = None
     assignee_id: uuid.UUID | None = None
 
@@ -83,8 +85,12 @@ class TicketResponse(BaseModel):
     description: str | None
     priority: str
     type: str
-    size: str
     labels: list[str]
+    size: str | None
+    size_bucket: str | None
+    size_source: str | None
+    size_confidence: float | None
+    size_updated_at: datetime | None
     due_date: date | None
     position: int
     assignee: TicketAssigneeResponse | None = None
@@ -96,6 +102,13 @@ class TicketResponse(BaseModel):
 
 
 class BoardTicketsResponse(BaseModel):
-    """All tickets for a project board."""
+    """All tickets for a project, grouped for the board."""
 
+    tickets: list[TicketResponse]
+
+
+class TicketBatchSizingResponse(BaseModel):
+    """Result payload for on-demand project ticket sizing."""
+
+    updated_count: int
     tickets: list[TicketResponse]

--- a/apps/web-backend/web_backend/services/tickets.py
+++ b/apps/web-backend/web_backend/services/tickets.py
@@ -1,6 +1,11 @@
-"""Ticket business logic."""
+"""Ticket business logic.
+
+Handles ticket creation, updates, sizing, moves (drag-and-drop),
+and deletion. Routes call these — no direct DB queries in routes.
+"""
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,92 +14,260 @@ from sqlalchemy.orm import selectinload
 from web_backend.models.project import Project, ProjectBoardColumn, ProjectMember
 from web_backend.models.ticket import ProjectTicket, ProjectTicketCounter
 from web_backend.models.user import AuthUser
+from web_backend.schemas.inference import TicketSizePredictionRequest
 from web_backend.schemas.tickets import (
     TicketCreateRequest,
     TicketMoveRequest,
     TicketUpdateRequest,
 )
+from web_backend.services.recommendations import (
+    apply_ticket_completion_profile_update,
+    is_completion_column_name,
+    sync_project_ticket_to_ml_tables,
+)
+from web_backend.services.inference import predict_ticket_size
+from shared.logging import get_logger
+
+logger = get_logger(__name__)
+
+MANUAL_SIZE_SOURCE = "manual"
+PREDICTED_SIZE_SOURCE = "predicted"
+SIZE_RECOMPUTE_FIELDS = {"title", "description", "labels", "type"}
 
 
-async def _verify_membership(db, project_id, user_id):
+# ------------------------------------------------------------------ #
+#  Helpers
+# ------------------------------------------------------------------ #
+
+
+async def _verify_membership(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ProjectMember:
+    """Verify user is a member of the project. Raises ValueError if not."""
     result = await db.execute(
         select(ProjectMember).where(
             ProjectMember.project_id == project_id,
             ProjectMember.user_id == user_id,
         )
     )
-    m = result.scalar_one_or_none()
-    if m is None:
-        raise ValueError("You are not a member of this project")
-    return m
+    membership = result.scalar_one_or_none()
+    if membership is None:
+        msg = "You are not a member of this project"
+        raise ValueError(msg)
+    return membership
 
 
-async def _get_project_by_slug(db, slug):
+async def _get_project_by_slug(db: AsyncSession, slug: str) -> Project:
+    """Fetch project by slug. Raises ValueError if not found."""
     result = await db.execute(select(Project).where(Project.slug == slug))
-    p = result.scalar_one_or_none()
-    if p is None:
-        raise ValueError("Project not found")
-    return p
+    project = result.scalar_one_or_none()
+    if project is None:
+        msg = "Project not found"
+        raise ValueError(msg)
+    return project
 
 
-async def _generate_ticket_key(db, project_id, project_slug):
+async def _generate_ticket_key(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    project_slug: str,
+) -> str:
+    """Generate the next ticket key like TF-1, TF-2, etc."""
+    # Get or create counter
     result = await db.execute(
-        select(ProjectTicketCounter).where(ProjectTicketCounter.project_id == project_id)
+        select(ProjectTicketCounter).where(
+            ProjectTicketCounter.project_id == project_id
+        )
     )
     counter_row = result.scalar_one_or_none()
+
     if counter_row is None:
         counter_row = ProjectTicketCounter(project_id=project_id, counter=0)
         db.add(counter_row)
         await db.flush()
+
     counter_row.counter += 1
+    next_num = counter_row.counter
+
+    # Build prefix from slug (e.g. "my-project" → "MY" or "testing" → "TEST")
     parts = project_slug.upper().split("-")
     prefix = parts[0][:5] if parts else "TF"
-    return f"{prefix}-{counter_row.counter}"
+
+    return f"{prefix}-{next_num}"
 
 
-async def _get_next_position(db, column_id):
+async def _get_next_position(
+    db: AsyncSession,
+    column_id: uuid.UUID,
+) -> int:
+    """Get the next position value for a column."""
     result = await db.execute(
         select(func.coalesce(func.max(ProjectTicket.position), -1)).where(
             ProjectTicket.column_id == column_id
         )
     )
-    return result.scalar_one() + 1
+    max_pos = result.scalar_one()
+    return max_pos + 1
 
 
-async def _get_ticket_loaded(db, ticket_id):
-    result = await db.execute(
-        select(ProjectTicket)
-        .where(ProjectTicket.id == ticket_id)
-        .options(selectinload(ProjectTicket.assignee))
+def _assign_manual_size(ticket: ProjectTicket, size_bucket: str | None) -> None:
+    """Persist a user-provided size override on a ticket.
+
+    Args:
+        ticket: Ticket being modified.
+        size_bucket: Explicit size bucket. ``None`` clears any stored size so the
+            backend can fall back to prediction.
+    """
+    if size_bucket is None:
+        ticket.size_bucket = None
+        ticket.size_source = None
+        ticket.size_confidence = None
+        ticket.size_updated_at = None
+        return
+
+    ticket.size_bucket = size_bucket
+    ticket.size_source = MANUAL_SIZE_SOURCE
+    ticket.size_confidence = None
+    ticket.size_updated_at = datetime.now(UTC)
+
+
+def _build_ticket_prediction_request(
+    project: Project,
+    ticket: ProjectTicket,
+    *,
+    rail: str,
+) -> TicketSizePredictionRequest:
+    """Convert a project ticket into the serving payload shape.
+
+    Args:
+        project: Project that owns the ticket.
+        ticket: Ticket to classify.
+        rail: Logical serving rail label for inference telemetry.
+
+    Returns:
+        TicketSizePredictionRequest for the production classifier.
+    """
+    assigned_at = ticket.updated_at if ticket.assignee_id is not None else None
+    return TicketSizePredictionRequest(
+        title=ticket.title,
+        body=ticket.description or "",
+        repo=project.slug,
+        issue_type=ticket.type,
+        labels=[str(label) for label in (ticket.labels or [])],
+        comments_count=0,
+        historical_avg_completion_hours=0.0,
+        created_at=ticket.created_at,
+        assigned_at=assigned_at,
+        rail=rail,
     )
-    t = result.scalar_one_or_none()
-    if t is None:
-        raise ValueError("Ticket not found")
-    return t
 
 
-async def create_ticket(db, slug, data: TicketCreateRequest, user: AuthUser):
+async def _predict_and_persist_ticket_size(
+    db: AsyncSession,
+    *,
+    project: Project,
+    ticket: ProjectTicket,
+    rail: str,
+) -> bool:
+    """Infer and store a ticket size without breaking the main request path.
+
+    Args:
+        db: Active async database session.
+        project: Project that owns the ticket.
+        ticket: Ticket to classify.
+        rail: Serving telemetry rail label.
+
+    Returns:
+        ``True`` when a prediction was stored, otherwise ``False``.
+    """
+    project_slug = project.slug
+    ticket_key = ticket.ticket_key
+
+    try:
+        prediction = await predict_ticket_size(
+            db,
+            _build_ticket_prediction_request(project, ticket, rail=rail),
+        )
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "Failed to predict ticket size for project=%s ticket=%s",
+            project_slug,
+            ticket_key,
+        )
+        return False
+
+    ticket.size_bucket = prediction.predicted_bucket
+    ticket.size_source = PREDICTED_SIZE_SOURCE
+    ticket.size_confidence = prediction.confidence
+    ticket.size_updated_at = datetime.now(UTC)
+
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "Failed to persist predicted ticket size for project=%s ticket=%s",
+            project_slug,
+            ticket_key,
+        )
+        return False
+
+    return True
+
+
+# ------------------------------------------------------------------ #
+#  Create ticket
+# ------------------------------------------------------------------ #
+
+
+async def create_ticket(
+    db: AsyncSession,
+    slug: str,
+    data: TicketCreateRequest,
+    user: AuthUser,
+) -> ProjectTicket:
+    """Create a ticket in a project.
+
+    Raises:
+        ValueError: If project not found, not a member, or invalid column/assignee.
+    """
     project = await _get_project_by_slug(db, slug)
     await _verify_membership(db, project.id, user.id)
+
+    # Verify column belongs to this project
     col_result = await db.execute(
         select(ProjectBoardColumn).where(
             ProjectBoardColumn.id == data.column_id,
             ProjectBoardColumn.project_id == project.id,
         )
     )
-    if col_result.scalar_one_or_none() is None:
-        raise ValueError("Invalid column for this project")
+    destination_column = col_result.scalar_one_or_none()
+    if destination_column is None:
+        msg = "Invalid column for this project"
+        raise ValueError(msg)
+
+    # Verify assignee is a project member (if provided)
     if data.assignee_id is not None:
-        a = await db.execute(
+        assignee_result = await db.execute(
             select(ProjectMember).where(
                 ProjectMember.project_id == project.id,
                 ProjectMember.user_id == data.assignee_id,
             )
         )
-        if a.scalar_one_or_none() is None:
-            raise ValueError("Assignee is not a member of this project")
+        if assignee_result.scalar_one_or_none() is None:
+            msg = "Assignee is not a member of this project"
+            raise ValueError(msg)
+
     ticket_key = await _generate_ticket_key(db, project.id, project.slug)
     position = await _get_next_position(db, data.column_id)
+
+    requested_manual_size = (
+        data.size_bucket if data.size_bucket is not None else data.size
+    )
+
     ticket = ProjectTicket(
         project_id=project.id,
         column_id=data.column_id,
@@ -105,19 +278,52 @@ async def create_ticket(db, slug, data: TicketCreateRequest, user: AuthUser):
         description=data.description,
         priority=data.priority,
         type=data.type,
-        size=data.size,
         labels=data.labels,
+        size_bucket=requested_manual_size,
+        size_source=MANUAL_SIZE_SOURCE if requested_manual_size is not None else None,
+        size_updated_at=datetime.now(UTC)
+        if requested_manual_size is not None
+        else None,
         due_date=data.due_date,
         position=position,
     )
     db.add(ticket)
     await db.commit()
-    return await _get_ticket_loaded(db, ticket.id)
+    await db.refresh(ticket)
+    await sync_project_ticket_to_ml_tables(db, project, ticket, destination_column)
+    await db.commit()
+
+    ticket = await _get_ticket_loaded(db, ticket.id)
+    ticket_id = ticket.id
+    if ticket.size_bucket is None:
+        await _predict_and_persist_ticket_size(
+            db,
+            project=project,
+            ticket=ticket,
+            rail="board_ticket_create",
+        )
+
+    return await _get_ticket_loaded(db, ticket_id)
 
 
-async def get_board_tickets(db, slug, user_id):
+# ------------------------------------------------------------------ #
+#  Get tickets for board
+# ------------------------------------------------------------------ #
+
+
+async def get_board_tickets(
+    db: AsyncSession,
+    slug: str,
+    user_id: uuid.UUID,
+) -> list[ProjectTicket]:
+    """Get all tickets for a project board.
+
+    Raises:
+        ValueError: If project not found or user not a member.
+    """
     project = await _get_project_by_slug(db, slug)
     await _verify_membership(db, project.id, user_id)
+
     result = await db.execute(
         select(ProjectTicket)
         .where(ProjectTicket.project_id == project.id)
@@ -127,23 +333,77 @@ async def get_board_tickets(db, slug, user_id):
     return list(result.scalars().all())
 
 
-async def get_ticket_by_key(db, slug, ticket_key, user_id):
-    project = await _get_project_by_slug(db, slug)
-    await _verify_membership(db, project.id, user_id)
+# ------------------------------------------------------------------ #
+#  Get single ticket
+# ------------------------------------------------------------------ #
+
+
+async def _get_ticket_loaded(
+    db: AsyncSession,
+    ticket_id: uuid.UUID,
+) -> ProjectTicket:
+    """Fetch a ticket with assignee loaded."""
     result = await db.execute(
         select(ProjectTicket)
-        .where(ProjectTicket.project_id == project.id, ProjectTicket.ticket_key == ticket_key)
+        .where(ProjectTicket.id == ticket_id)
         .options(selectinload(ProjectTicket.assignee))
     )
-    t = result.scalar_one_or_none()
-    if t is None:
-        raise ValueError("Ticket not found")
-    return t
+    ticket = result.scalar_one_or_none()
+    if ticket is None:
+        msg = "Ticket not found"
+        raise ValueError(msg)
+    return ticket
 
 
-async def update_ticket(db, slug, ticket_key, data: TicketUpdateRequest, user_id):
+async def get_ticket_by_key(
+    db: AsyncSession,
+    slug: str,
+    ticket_key: str,
+    user_id: uuid.UUID,
+) -> ProjectTicket:
+    """Get a single ticket by its key.
+
+    Raises:
+        ValueError: If not found or user not a member.
+    """
     project = await _get_project_by_slug(db, slug)
     await _verify_membership(db, project.id, user_id)
+
+    result = await db.execute(
+        select(ProjectTicket)
+        .where(
+            ProjectTicket.project_id == project.id,
+            ProjectTicket.ticket_key == ticket_key,
+        )
+        .options(selectinload(ProjectTicket.assignee))
+    )
+    ticket = result.scalar_one_or_none()
+    if ticket is None:
+        msg = "Ticket not found"
+        raise ValueError(msg)
+    return ticket
+
+
+# ------------------------------------------------------------------ #
+#  Update ticket
+# ------------------------------------------------------------------ #
+
+
+async def update_ticket(
+    db: AsyncSession,
+    slug: str,
+    ticket_key: str,
+    data: TicketUpdateRequest,
+    user_id: uuid.UUID,
+) -> ProjectTicket:
+    """Update ticket fields.
+
+    Raises:
+        ValueError: If not found, not a member, or invalid assignee.
+    """
+    project = await _get_project_by_slug(db, slug)
+    await _verify_membership(db, project.id, user_id)
+
     result = await db.execute(
         select(ProjectTicket).where(
             ProjectTicket.project_id == project.id,
@@ -152,33 +412,151 @@ async def update_ticket(db, slug, ticket_key, data: TicketUpdateRequest, user_id
     )
     ticket = result.scalar_one_or_none()
     if ticket is None:
-        raise ValueError("Ticket not found")
+        msg = "Ticket not found"
+        raise ValueError(msg)
+
+    # Validate assignee if changing
     if data.assignee_id is not None:
-        a = await db.execute(
+        assignee_check = await db.execute(
             select(ProjectMember).where(
                 ProjectMember.project_id == project.id,
                 ProjectMember.user_id == data.assignee_id,
             )
         )
-        if a.scalar_one_or_none() is None:
-            raise ValueError("Assignee is not a member of this project")
-    for field, value in data.model_dump(exclude_unset=True).items():
+        if assignee_check.scalar_one_or_none() is None:
+            msg = "Assignee is not a member of this project"
+            raise ValueError(msg)
+
+    # Apply updates
+    update_fields = data.model_dump(exclude_unset=True)
+    legacy_size_provided = "size" in data.model_fields_set
+    manual_size_provided = (
+        "size_bucket" in data.model_fields_set or legacy_size_provided
+    )
+    requested_size_bucket = update_fields.pop("size_bucket", None)
+    requested_legacy_size = update_fields.pop("size", None)
+    requested_size = (
+        requested_size_bucket
+        if "size_bucket" in data.model_fields_set
+        else requested_legacy_size
+    )
+    recompute_prediction = bool(SIZE_RECOMPUTE_FIELDS.intersection(update_fields))
+
+    for field, value in update_fields.items():
         setattr(ticket, field, value)
+
     await db.commit()
-    return await _get_ticket_loaded(db, ticket.id)
+    await db.refresh(ticket)
+    column_result = await db.execute(
+        select(ProjectBoardColumn).where(ProjectBoardColumn.id == ticket.column_id)
+    )
+    current_column = column_result.scalar_one()
+    await sync_project_ticket_to_ml_tables(db, project, ticket, current_column)
+    await db.commit()
+
+    ticket = await _get_ticket_loaded(db, ticket.id)
+    ticket_id = ticket.id
+
+    if manual_size_provided:
+        _assign_manual_size(ticket, requested_size)
+        await db.commit()
+        ticket = await _get_ticket_loaded(db, ticket.id)
+        if requested_size is None:
+            await _predict_and_persist_ticket_size(
+                db,
+                project=project,
+                ticket=ticket,
+                rail="board_ticket_update",
+            )
+            return await _get_ticket_loaded(db, ticket_id)
+
+    if ticket.size_source != MANUAL_SIZE_SOURCE and (
+        ticket.size_bucket is None or recompute_prediction
+    ):
+        await _predict_and_persist_ticket_size(
+            db,
+            project=project,
+            ticket=ticket,
+            rail="board_ticket_update",
+        )
+
+    return await _get_ticket_loaded(db, ticket_id)
 
 
-async def move_ticket(db, slug, ticket_key, data: TicketMoveRequest, user_id):
+# ------------------------------------------------------------------ #
+#  Batch classify unsized tickets
+# ------------------------------------------------------------------ #
+
+
+async def classify_missing_ticket_sizes(
+    db: AsyncSession,
+    slug: str,
+    user_id: uuid.UUID,
+) -> tuple[int, list[ProjectTicket]]:
+    """Classify and persist any unsized tickets for a project."""
     project = await _get_project_by_slug(db, slug)
     await _verify_membership(db, project.id, user_id)
+
+    result = await db.execute(
+        select(ProjectTicket)
+        .where(
+            ProjectTicket.project_id == project.id,
+            ProjectTicket.size_bucket.is_(None),
+        )
+        .options(selectinload(ProjectTicket.assignee))
+        .order_by(ProjectTicket.position)
+    )
+    tickets = list(result.scalars().all())
+
+    updated_count = 0
+    for ticket in tickets:
+        updated_count += int(
+            await _predict_and_persist_ticket_size(
+                db,
+                project=project,
+                ticket=ticket,
+                rail="board_ticket_batch",
+            )
+        )
+
+    refreshed_tickets = await get_board_tickets(db, slug, user_id)
+    return updated_count, refreshed_tickets
+
+
+# ------------------------------------------------------------------ #
+#  Move ticket (drag-and-drop)
+# ------------------------------------------------------------------ #
+
+
+async def move_ticket(
+    db: AsyncSession,
+    slug: str,
+    ticket_key: str,
+    data: TicketMoveRequest,
+    user_id: uuid.UUID,
+) -> ProjectTicket:
+    """Move a ticket to a different column/position.
+
+    Reorders other tickets in the destination column to make room.
+
+    Raises:
+        ValueError: If not found, not a member, or invalid column.
+    """
+    project = await _get_project_by_slug(db, slug)
+    await _verify_membership(db, project.id, user_id)
+
+    # Verify destination column
     col_result = await db.execute(
         select(ProjectBoardColumn).where(
             ProjectBoardColumn.id == data.column_id,
             ProjectBoardColumn.project_id == project.id,
         )
     )
-    if col_result.scalar_one_or_none() is None:
-        raise ValueError("Invalid column for this project")
+    destination_column = col_result.scalar_one_or_none()
+    if destination_column is None:
+        msg = "Invalid column for this project"
+        raise ValueError(msg)
+
     result = await db.execute(
         select(ProjectTicket).where(
             ProjectTicket.project_id == project.id,
@@ -187,52 +565,103 @@ async def move_ticket(db, slug, ticket_key, data: TicketMoveRequest, user_id):
     )
     ticket = result.scalar_one_or_none()
     if ticket is None:
-        raise ValueError("Ticket not found")
+        msg = "Ticket not found"
+        raise ValueError(msg)
+
     old_column_id = ticket.column_id
     old_position = ticket.position
+    old_column_result = await db.execute(
+        select(ProjectBoardColumn).where(ProjectBoardColumn.id == old_column_id)
+    )
+    old_column = old_column_result.scalar_one()
+    was_complete = is_completion_column_name(old_column.name)
+    is_complete = is_completion_column_name(destination_column.name)
+
+    # If moving within the same column
     if old_column_id == data.column_id:
         if data.position > old_position:
+            # Moving down — shift others up
             await db.execute(
-                update(ProjectTicket).where(
+                update(ProjectTicket)
+                .where(
                     ProjectTicket.column_id == data.column_id,
                     ProjectTicket.position > old_position,
                     ProjectTicket.position <= data.position,
                     ProjectTicket.id != ticket.id,
-                ).values(position=ProjectTicket.position - 1)
+                )
+                .values(position=ProjectTicket.position - 1)
             )
         elif data.position < old_position:
+            # Moving up — shift others down
             await db.execute(
-                update(ProjectTicket).where(
+                update(ProjectTicket)
+                .where(
                     ProjectTicket.column_id == data.column_id,
                     ProjectTicket.position >= data.position,
                     ProjectTicket.position < old_position,
                     ProjectTicket.id != ticket.id,
-                ).values(position=ProjectTicket.position + 1)
+                )
+                .values(position=ProjectTicket.position + 1)
             )
     else:
+        # Moving to different column
+        # Close gap in source column
         await db.execute(
-            update(ProjectTicket).where(
+            update(ProjectTicket)
+            .where(
                 ProjectTicket.column_id == old_column_id,
                 ProjectTicket.position > old_position,
                 ProjectTicket.id != ticket.id,
-            ).values(position=ProjectTicket.position - 1)
+            )
+            .values(position=ProjectTicket.position - 1)
         )
+        # Make room in destination column
         await db.execute(
-            update(ProjectTicket).where(
+            update(ProjectTicket)
+            .where(
                 ProjectTicket.column_id == data.column_id,
                 ProjectTicket.position >= data.position,
                 ProjectTicket.id != ticket.id,
-            ).values(position=ProjectTicket.position + 1)
+            )
+            .values(position=ProjectTicket.position + 1)
         )
+
     ticket.column_id = data.column_id
     ticket.position = data.position
+
     await db.commit()
+    await db.refresh(ticket)
+    await sync_project_ticket_to_ml_tables(db, project, ticket, destination_column)
+    await db.commit()
+    if not was_complete and is_complete:
+        await apply_ticket_completion_profile_update(
+            db,
+            project=project,
+            ticket=ticket,
+            column=destination_column,
+        )
     return await _get_ticket_loaded(db, ticket.id)
 
 
-async def delete_ticket(db, slug, ticket_key, user_id):
+# ------------------------------------------------------------------ #
+#  Delete ticket
+# ------------------------------------------------------------------ #
+
+
+async def delete_ticket(
+    db: AsyncSession,
+    slug: str,
+    ticket_key: str,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a ticket. Any project member can delete.
+
+    Raises:
+        ValueError: If not found or not a member.
+    """
     project = await _get_project_by_slug(db, slug)
     await _verify_membership(db, project.id, user_id)
+
     result = await db.execute(
         select(ProjectTicket).where(
             ProjectTicket.project_id == project.id,
@@ -241,14 +670,22 @@ async def delete_ticket(db, slug, ticket_key, user_id):
     )
     ticket = result.scalar_one_or_none()
     if ticket is None:
-        raise ValueError("Ticket not found")
+        msg = "Ticket not found"
+        raise ValueError(msg)
+
     column_id = ticket.column_id
     position = ticket.position
+
     await db.delete(ticket)
+
+    # Close gap in column
     await db.execute(
-        update(ProjectTicket).where(
+        update(ProjectTicket)
+        .where(
             ProjectTicket.column_id == column_id,
             ProjectTicket.position > position,
-        ).values(position=ProjectTicket.position - 1)
+        )
+        .values(position=ProjectTicket.position - 1)
     )
+
     await db.commit()

--- a/apps/web-frontend/src/components/projects/board/board-view.tsx
+++ b/apps/web-frontend/src/components/projects/board/board-view.tsx
@@ -12,6 +12,7 @@ import {
   type BoardColumn as ApiBoardColumn,
   type ProjectMember,
   type TicketResponse,
+  classifyMissingTicketSizes,
   getBoardTickets,
   createTicket as apiCreateTicket,
   moveTicket as apiMoveTicket,
@@ -51,7 +52,7 @@ function apiTicketToCard(
     title: t.title,
     type: t.type as TicketData["type"],
     priority: t.priority as TicketData["priority"],
-    size: (t.size || "M") as TicketData["size"],
+    size: (t.size_bucket || t.size || "M") as TicketData["size"],
     labels: t.labels || [],
     dueDate: t.due_date
       ? new Date(t.due_date + "T00:00:00").toLocaleDateString("en-US", {
@@ -132,6 +133,21 @@ export function BoardView({
       if (data) {
         setRawTickets(data.tickets);
         setColumns(buildColumns(boardColumns, data.tickets, memberIndex));
+
+        if (data.tickets.some((ticket) => !ticket.size_bucket)) {
+          const sized = await classifyMissingTicketSizes(token, projectSlug);
+          if (sized.data) {
+            setRawTickets(sized.data.tickets);
+            setColumns(buildColumns(boardColumns, sized.data.tickets, memberIndex));
+            if (sized.data.updated_count > 0) {
+              toast.success(
+                `AI sized ${sized.data.updated_count} ticket${
+                  sized.data.updated_count === 1 ? "" : "s"
+                }`,
+              );
+            }
+          }
+        }
       }
       setIsLoading(false);
     }
@@ -296,6 +312,11 @@ export function BoardView({
       </DragDropContext>
 
       <TicketDetailModal
+        key={
+          selectedRawTicket
+            ? `${selectedRawTicket.ticket_key}:${modalOpen ? "open" : "closed"}`
+            : "ticket-modal"
+        }
         ticket={selectedRawTicket}
         projectSlug={projectSlug}
         members={members}

--- a/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
+++ b/apps/web-frontend/src/components/projects/board/ticket-detail-modal.tsx
@@ -70,6 +70,7 @@ const typeOptions = [
 ];
 
 const sizeOptions = [
+  { value: "auto", label: "Auto (AI estimate)", short: "AI" },
   { value: "S", label: "Small", short: "S" },
   { value: "M", label: "Medium", short: "M" },
   { value: "L", label: "Large", short: "L" },
@@ -133,12 +134,19 @@ export function TicketDetailModal({
   onUpdated,
   onDeleted,
 }: TicketDetailModalProps) {
+  type SizeValue = "S" | "M" | "L" | "XL";
+  type SizeMode = SizeValue | "auto";
+
   const { token } = useAuth();
   const [title, setTitle] = useState(ticket?.title || "");
   const [description, setDescription] = useState(ticket?.description || "");
   const [priority, setPriority] = useState(ticket?.priority || "medium");
   const [type, setType] = useState(ticket?.type || "task");
-  const [size, setSize] = useState(ticket?.size || "M");
+  const [sizeMode, setSizeMode] = useState<SizeMode>(
+    ticket?.size_source === "manual" && ticket?.size_bucket
+      ? (ticket.size_bucket as SizeValue)
+      : "auto",
+  );
   const [assigneeId, setAssigneeId] = useState<string | null>(
     ticket?.assignee?.id || null
   );
@@ -162,7 +170,7 @@ export function TicketDetailModal({
         description: description.trim() || undefined,
         priority,
         type,
-        size,
+        size_bucket: sizeMode === "auto" ? null : sizeMode,
         assignee_id: assigneeId,
         due_date: dueDate || undefined,
         labels,
@@ -181,7 +189,7 @@ export function TicketDetailModal({
     }
   }, [
     token, ticket, projectSlug, title, description,
-    priority, type, size, assigneeId, dueDate, labels,
+    priority, type, sizeMode, assigneeId, dueDate, labels,
     onUpdated, onClose,
   ]);
 
@@ -220,7 +228,11 @@ export function TicketDetailModal({
   const currentType = typeOptions.find((t) => t.value === type);
   const TypeIcon = currentType?.icon || CheckSquare;
   const currentPriority = priorityOptions.find((p) => p.value === priority);
-  const pointsCost = sizePointsMap[size as keyof typeof sizePointsMap] || 0;
+  const selectedOrPredictedSize = (
+    sizeMode === "auto" ? (ticket.size_bucket || ticket.size || "M") : sizeMode
+  ) as SizeValue;
+  const pointsCost =
+    sizePointsMap[selectedOrPredictedSize as keyof typeof sizePointsMap] || 0;
   const dueInfo = dueDate ? getDaysUntilDue(dueDate) : null;
 
   // Simulated AI recommended member
@@ -228,11 +240,11 @@ export function TicketDetailModal({
 
   return (
     <Dialog key={ticket.id} open={open} onOpenChange={(v) => !v && onClose()}>
-      {/* Container setup: 
+      {/* Container setup:
         Flex column so Header/Footer stick, with max-height to fit screen.
       */}
       <DialogContent className="flex max-h-[90vh] w-[94vw] flex-col overflow-hidden p-0 sm:w-[55vw] sm:!max-w-[900px]">
-        
+
         {/* ========== HEADER ========== */}
         <DialogHeader className="shrink-0 border-b bg-background px-5 py-3.5 shadow-sm z-10">
           <div className="flex items-center justify-between">
@@ -274,11 +286,11 @@ export function TicketDetailModal({
 
         {/* ========== SCROLLABLE BODY ========== */}
         <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
-          
+
           {/* LEFT SIDE: Main content */}
           <div className="flex-1 overflow-y-auto px-6 py-5">
             <div className="space-y-6">
-              
+
               {/* Title */}
               <div>
                 <Input
@@ -443,7 +455,7 @@ export function TicketDetailModal({
 
           {/* RIGHT SIDEBAR: Metadata */}
           <div className="w-full shrink-0 border-t md:border-l md:border-t-0 bg-muted/10 p-5 md:w-[260px] md:overflow-y-auto flex flex-col gap-5">
-            
+
             <div className="grid grid-cols-2 gap-4 md:grid-cols-1 md:gap-5">
               {/* Priority */}
               <div className="space-y-1.5">
@@ -473,10 +485,8 @@ export function TicketDetailModal({
                   Size
                 </Label>
                 <Select
-                  value={size}
-                  onValueChange={(value) =>
-                    setSize(value as "S" | "M" | "L" | "XL")
-                  }
+                  value={sizeMode}
+                  onValueChange={(value) => setSizeMode(value as SizeMode)}
                 >
                   <SelectTrigger className="h-9 text-sm bg-background">
                     <SelectValue />
@@ -485,13 +495,26 @@ export function TicketDetailModal({
                     {sizeOptions.map((opt) => (
                       <SelectItem key={opt.value} value={opt.value}>
                         <div className="flex items-center gap-2">
-                          <span className={cn("flex size-5 items-center justify-center rounded text-[10px] font-bold", sizeColors[opt.value])}>
-                            {opt.short}
-                          </span>
+                          {opt.value === "auto" ? (
+                            <span className="flex size-5 items-center justify-center rounded bg-muted text-[10px] font-bold text-muted-foreground">
+                              {opt.short}
+                            </span>
+                          ) : (
+                            <span
+                              className={cn(
+                                "flex size-5 items-center justify-center rounded text-[10px] font-bold",
+                                sizeColors[opt.value],
+                              )}
+                            >
+                              {opt.short}
+                            </span>
+                          )}
                           <span>{opt.label}</span>
-                          <span className="ml-auto text-[10px] text-muted-foreground">
-                            ({sizePointsMap[opt.value as keyof typeof sizePointsMap]}pt)
-                          </span>
+                          {opt.value !== "auto" && (
+                            <span className="ml-auto text-[10px] text-muted-foreground">
+                              ({sizePointsMap[opt.value as keyof typeof sizePointsMap]}pt)
+                            </span>
+                          )}
                         </div>
                       </SelectItem>
                     ))}
@@ -565,8 +588,15 @@ export function TicketDetailModal({
                 </span>
                 <span className="text-muted-foreground">Status</span>
                 <span className="text-right">
-                  <span className={cn("rounded px-1.5 py-0.5 text-[10px] font-bold", sizeColors[size])}>
-                    {size}
+                  <span
+                    className={cn(
+                      "rounded px-1.5 py-0.5 text-[10px] font-bold",
+                      sizeColors[selectedOrPredictedSize],
+                    )}
+                  >
+                    {sizeMode === "auto"
+                      ? `AI ${selectedOrPredictedSize}`
+                      : selectedOrPredictedSize}
                   </span>
                 </span>
                 <span className="text-muted-foreground">Level</span>

--- a/apps/web-frontend/src/lib/api.ts
+++ b/apps/web-frontend/src/lib/api.ts
@@ -100,7 +100,7 @@ export interface TicketResponse {
   description: string | null;
   priority: string;
   type: string;
-  size: "S" | "M" | "L" | "XL";
+  size?: "S" | "M" | "L" | "XL";
   labels: string[];
   size_bucket: string | null;
   size_source: string | null;


### PR DESCRIPTION
What this fixes\n- Restores the ticket sizing backend that was regressed on main (ticket model/schema/routes/services now use persisted size_bucket + size_source + confidence metadata).\n- Restores and wires POST /api/v1/projects/{slug}/tickets/classify-missing to batch-classify unsized board tickets.\n- Keeps UI compatibility by accepting legacy size payloads while treating size_bucket as source of truth.\n- Updates board loading to auto-trigger classify-missing when unsized tickets exist and refresh the board with persisted predictions.\n- Updates ticket modal to support Auto (AI estimate) mode so saves no longer force manual M by default.\n- Adds regression tests for legacy size compatibility mapping.\n\nValidation (local)\n- just pytest apps/web-backend/tests/test_ticket_sizing.py apps/web-backend/tests/test_recommendations.py\n- just pytest apps/web-backend/tests\n- just pylint apps/web-backend/web_backend/api/v1/tickets.py apps/web-backend/web_backend/schemas/tickets.py apps/web-backend/web_backend/services/tickets.py apps/web-backend/tests/test_ticket_sizing.py\n- npm run lint (apps/web-frontend)\n- npm run typecheck (apps/web-frontend)\n\nNote\n- npm run build in this environment fails on fetching Google Fonts (Geist/Geist Mono) due outbound network restrictions, not due app code errors.