### PR TITLE
fix: add serviceAccountKeyAdmin role to terraform apply SA

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -95,6 +95,7 @@ locals {
     "roles/secretmanager.admin",             # Manage Secret Manager secrets/versions/iam
     "roles/storage.admin",                   # Manage GCS Buckets
     "roles/iam.serviceAccountAdmin",         # REQUIRED: To create/manage runtime service accounts during bootstrap
+    "roles/iam.serviceAccountKeyAdmin",      # REQUIRED: To create service account keys (mlflow GCS signing key)
     "roles/iam.serviceAccountUser",          # REQUIRED: To attach Service Accounts to Compute/Cloud Run
     "roles/iam.securityReviewer",            # View IAM policies
     "roles/iam.workloadIdentityPoolAdmin",   # REQUIRED: To manage workload identity pools (includes iam.workloadIdentityPools.get)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,6 +111,10 @@ resource "google_compute_instance" "airflow_vm" {
     on_host_maintenance = "MIGRATE"
   }
 
+  lifecycle {
+    ignore_changes = [metadata_startup_script]
+  }
+
   depends_on = [
     google_project_service.airflow_services,
     google_sql_database.airflow,


### PR DESCRIPTION
## Summary
- Adds `roles/iam.serviceAccountKeyAdmin` to the terraform apply service account
- Fixes Airflow deploy failure: `Permission 'iam.serviceAccountKeys.create' denied` when creating `google_service_account_key.mlflow_server_signing` from Will's mlflow.tf changes

## Test plan
- [ ] After merge: Airflow Deploy workflow should not fail on IAM permission
- [ ] TF Validate/Plan should pass (CI tfvars fix already merged in #167)