### PR TITLE
fix: remove full ticket sync from engineer recommendation reads

### DIFF
--- a/apps/web-backend/tests/test_recommendations.py
+++ b/apps/web-backend/tests/test_recommendations.py
@@ -336,3 +336,60 @@ class TestCompletionSync:
         db_session.add(user)
         await db_session.flush()
         return user
+
+
+class TestEngineerTicketRecommendations:
+    """Engineer ticket recommendation service coverage."""
+
+    async def test_recommendations_do_not_full_sync_project_tickets(
+        self, db_session
+    ) -> None:
+        """Engineer ticket recommendations should not trigger a full project sync."""
+        from web_backend.services.recommendations import recommend_tickets_for_engineer
+
+        current_user_id = uuid.uuid4()
+        engineer_user_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+        project = SimpleNamespace(id=project_id)
+        engineer_profile = SimpleNamespace(
+            user_id=engineer_user_id,
+            username="janedoe",
+            first_name="Jane",
+            last_name="Doe",
+            email="jane@example.com",
+            member_id=101,
+        )
+        query_result = SimpleNamespace(mappings=lambda: SimpleNamespace(all=lambda: []))
+
+        with (
+            patch(
+                "web_backend.services.recommendations._get_project_for_member_validation",
+                new=AsyncMock(return_value=project),
+            ),
+            patch(
+                "web_backend.services.recommendations._get_target_project_member",
+                new=AsyncMock(return_value=SimpleNamespace(user_id=engineer_user_id)),
+            ),
+            patch(
+                "web_backend.services.recommendations.ensure_project_member_profiles",
+                new=AsyncMock(return_value={engineer_user_id: engineer_profile}),
+            ),
+            patch(
+                "web_backend.services.recommendations.sync_project_tickets_for_recommendations",
+                new=AsyncMock(),
+            ) as full_sync,
+            patch.object(
+                db_session,
+                "execute",
+                new=AsyncMock(
+                    side_effect=[SimpleNamespace(scalar_one=lambda: 0), query_result]
+                ),
+            ),
+        ):
+            response = await recommend_tickets_for_engineer(
+                db_session, "demo-project", engineer_user_id, current_user_id
+            )
+
+        full_sync.assert_not_awaited()
+        assert response.user_id == engineer_user_id
+        assert response.recommendations == []

--- a/apps/web-backend/web_backend/services/recommendations.py
+++ b/apps/web-backend/web_backend/services/recommendations.py
@@ -14,6 +14,10 @@ try:
 
     _HAS_ML = True
 except ImportError:
+    get_embedding_service = None
+    get_keyword_extractor = None
+    ProfileUpdater = None
+    vector_to_pgvector_text = None
     _HAS_ML = False
 
 from sqlalchemy import func, select, text
@@ -262,6 +266,9 @@ def _embed_ticket_text(title: str, description: str | None) -> tuple[str, str]:
         msg = "ml-core is required for embedding tickets"
         raise RuntimeError(msg)
 
+    assert get_embedding_service is not None
+    assert get_keyword_extractor is not None
+    assert vector_to_pgvector_text is not None
     embedding_service = get_embedding_service()
     keyword_extractor = get_keyword_extractor()
     combined_text = f"{title}\n{description or ''}".strip()
@@ -526,9 +533,6 @@ async def recommend_tickets_for_engineer(
     await _get_target_project_member(db, project.id, engineer_user_id)
     member_profiles = await ensure_project_member_profiles(db, project.id)
 
-    if _HAS_ML:
-        await sync_project_tickets_for_recommendations(db, project)
-
     target_profile = member_profiles.get(engineer_user_id)
     if target_profile is None:
         msg = "Engineer profile not found"
@@ -679,6 +683,8 @@ async def apply_ticket_completion_profile_update(
     profile = await _ensure_member_profile(db, assignee)
     await sync_project_ticket_to_ml_tables(db, project, ticket, column)
 
+    assert get_keyword_extractor is not None
+    assert ProfileUpdater is not None
     keyword_extractor = get_keyword_extractor()
     updater = ProfileUpdater()
     ticket_text = f"{ticket.title} {ticket.description or ''}".strip()


### PR DESCRIPTION
## Description

### Motivation
Resolves: 

Clicking a member in the Team tab called the engineer-ticket recommendation endpoint, and that endpoint was running a full project ticket sync before computing recommendations. On seeded projects with many tickets, this made the recommendation modal slow because every request re-embedded and upserted all project tickets before returning results.

### Implemented Changes
- Removed the full-project ML ticket sync from `recommend_tickets_for_engineer(...)`.
- Kept engineer-ticket recommendations as a read against already-synced ML data.
- Left existing single-ticket sync behavior in place for normal ticket mutation flows.
- Added a regression test to verify engineer-ticket recommendations do not trigger full-project sync.

## How has this been tested?

- Added backend regression coverage in `apps/web-backend/tests/test_recommendations.py`.
- Verified the recommendation route test still passes.
- Verified the new service-level test passes and confirms full sync is not called.
- Ran:
  - `uv run ruff check apps/web-backend/web_backend/services/recommendations.py apps/web-backend/tests/test_recommendations.py`
  - `uv run pyright apps/web-backend/web_backend/services/recommendations.py apps/web-backend/tests/test_recommendations.py`
  - `uv run pytest apps/web-backend/tests/test_recommendations.py::TestRecommendationRoutes::test_engineer_recommendations_return_payload apps/web-backend/tests/test_recommendations.py::TestEngineerTicketRecommendations::test_recommendations_do_not_full_sync_project_tickets -q`

## Screenshots
N/A

## Checklist:

- [x] I followed code style of the project.
- [ ] I've updated all documentation accordingly.
- [x] I've added tests to cover my changes.
- [x] I've ensured all tests pass (no regressions).
